### PR TITLE
feat(security): 加密密码存储

### DIFF
--- a/course_schedule.py
+++ b/course_schedule.py
@@ -14,6 +14,11 @@ import requests
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
 from schedule_cleaner import clean_schedule_grid_file
+from secure_storage import (
+    load_encrypted_profile,
+    save_encrypted_profile,
+    decrypt_value,
+)
 
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -690,13 +695,14 @@ if __name__ == "__main__":
     if args.quick == "fetch":
         args.fetch = True
 
-    profile = load_json(PROFILE_FILE)
+    # 使用加密存储加载配置
+    profile = load_encrypted_profile(PROFILE_FILE)
 
     if args.setup:
         profile["student_id"] = prompt_text("学号", str(profile.get("student_id", "") or ""))
         pwd_input = prompt_password(default_exists=bool(profile.get("password")))
         profile["password"] = pwd_input or str(profile.get("password", "") or "")
-        save_json(PROFILE_FILE, profile)
+        save_encrypted_profile(PROFILE_FILE, profile)
         print(f"配置已保存: {PROFILE_FILE}")
 
     if args.show:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -26,6 +26,13 @@ from course_schedule import (
     save_json,
 )
 from schedule_cleaner import clean_schedule_grid_file, load_latest_clean_schedule
+from secure_storage import (
+    encrypt_value,
+    decrypt_value,
+    is_encrypted,
+    load_encrypted_profile,
+    save_encrypted_profile,
+)
 
 mcp = FastMCP("henu-campus-unified")
 BASE_DIR = Path(__file__).resolve().parent
@@ -631,7 +638,8 @@ def get_current_course_status(
 
 
 def _effective_profile() -> dict[str, Any]:
-    return load_json(PROFILE_FILE)
+    """加载并解密配置文件"""
+    return load_encrypted_profile(PROFILE_FILE)
 
 
 def _mask_profile(profile: dict[str, Any]) -> dict[str, Any]:
@@ -666,9 +674,10 @@ def _resolve_account(student_id: str, password: str, use_saved_account: bool = T
 
 
 def _save_profile_fields(fields: dict[str, Any]) -> None:
-    profile = load_json(PROFILE_FILE)
+    """加密并保存配置字段"""
+    profile = load_encrypted_profile(PROFILE_FILE)
     profile.update(fields)
-    save_json(PROFILE_FILE, profile)
+    save_encrypted_profile(PROFILE_FILE, profile)
 
 
 def _resolve_library_defaults() -> tuple[str, str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.28.0
 pycryptodome>=3.15.0
 lxml>=4.9.0
 mcp>=1.0.0
+cryptography>=41.0.0

--- a/secure_storage.py
+++ b/secure_storage.py
@@ -1,0 +1,203 @@
+"""
+安全存储模块 - 加密保存敏感数据（如密码）
+
+使用 Fernet 对称加密，密钥通过机器指纹派生。
+"""
+
+import base64
+import hashlib
+import json
+import os
+import platform
+import sys
+from pathlib import Path
+from typing import Any
+
+# 延迟导入 cryptography，仅在需要时加载
+_fernet = None
+
+
+def _get_fernet():
+    """延迟加载 Fernet"""
+    global _fernet
+    if _fernet is None:
+        try:
+            from cryptography.fernet import Fernet
+            _fernet = Fernet
+        except ImportError:
+            raise ImportError(
+                "加密功能需要 cryptography 库。请运行: pip install cryptography"
+            )
+    return _fernet
+
+
+def _machine_fingerprint() -> str:
+    """
+    生成机器指纹用于派生加密密钥。
+    使用多种系统信息组合，确保密钥在同一台机器上稳定。
+    """
+    components = [
+        platform.node(),  # 主机名
+        platform.system(),  # 操作系统
+        platform.machine(),  # 机器类型
+        str(os.getuid() if hasattr(os, 'getuid') else os.getpid()),  # 用户ID或进程ID
+    ]
+
+    # 添加用户主目录路径作为额外因子
+    home = str(Path.home())
+    components.append(home)
+
+    # 组合生成指纹
+    combined = "|".join(components)
+    return hashlib.sha256(combined.encode('utf-8')).hexdigest()
+
+
+def _derive_key() -> bytes:
+    """
+    从机器指纹派生 Fernet 密钥。
+    Fernet 需要 32 字节的 URL-safe base64 编码密钥。
+    """
+    fingerprint = _machine_fingerprint()
+    # 使用 SHA256 派生 32 字节密钥
+    key_bytes = hashlib.sha256(fingerprint.encode('utf-8')).digest()
+    # 转换为 URL-safe base64 格式
+    return base64.urlsafe_b64encode(key_bytes)
+
+
+def encrypt_value(plaintext: str) -> str:
+    """
+    加密字符串值。
+
+    Args:
+        plaintext: 明文字符串
+
+    Returns:
+        加密后的字符串（包含前缀标识）
+    """
+    if not plaintext:
+        return ""
+
+    Fernet = _get_fernet()
+    key = _derive_key()
+    f = Fernet(key)
+    encrypted = f.encrypt(plaintext.encode('utf-8'))
+    return "enc:" + encrypted.decode('utf-8')
+
+
+def decrypt_value(encrypted: str) -> str:
+    """
+    解密字符串值。
+
+    Args:
+        encrypted: 加密的字符串（带 enc: 前缀）
+
+    Returns:
+        解密后的明文字符串
+    """
+    if not encrypted:
+        return ""
+
+    # 如果没有加密前缀，可能是旧版明文数据
+    if not encrypted.startswith("enc:"):
+        return encrypted
+
+    Fernet = _get_fernet()
+    key = _derive_key()
+    f = Fernet(key)
+
+    try:
+        ciphertext = encrypted[4:]  # 移除 "enc:" 前缀
+        decrypted = f.decrypt(ciphertext.encode('utf-8'))
+        return decrypted.decode('utf-8')
+    except Exception:
+        # 解密失败，可能密钥变化或数据损坏
+        return ""
+
+
+def is_encrypted(value: str) -> bool:
+    """检查值是否已加密"""
+    return bool(value) and value.startswith("enc:")
+
+
+def migrate_profile(profile_path: Path) -> dict[str, Any]:
+    """
+    迁移配置文件：加密明文密码。
+
+    Args:
+        profile_path: 配置文件路径
+
+    Returns:
+        迁移后的配置数据
+    """
+    if not profile_path.exists():
+        return {}
+
+    try:
+        data = json.loads(profile_path.read_text(encoding='utf-8'))
+    except Exception:
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    changed = False
+
+    # 加密明文密码
+    password = data.get("password")
+    if password and not is_encrypted(password):
+        data["password"] = encrypt_value(password)
+        changed = True
+
+    if changed:
+        profile_path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            encoding='utf-8'
+        )
+
+    return data
+
+
+def load_encrypted_profile(profile_path: Path) -> dict[str, Any]:
+    """
+    加载并解密配置文件。
+
+    Args:
+        profile_path: 配置文件路径
+
+    Returns:
+        解密后的配置数据
+    """
+    # 先尝试迁移
+    data = migrate_profile(profile_path)
+
+    if not data:
+        return {}
+
+    # 解密密码
+    password = data.get("password")
+    if password and is_encrypted(password):
+        data["password"] = decrypt_value(password)
+
+    return data
+
+
+def save_encrypted_profile(profile_path: Path, data: dict[str, Any]) -> None:
+    """
+    加密并保存配置文件。
+
+    Args:
+        profile_path: 配置文件路径
+        data: 配置数据（密码将被加密存储）
+    """
+    # 复制数据，避免修改原始对象
+    save_data = dict(data)
+
+    # 加密密码
+    password = save_data.get("password")
+    if password and not is_encrypted(password):
+        save_data["password"] = encrypt_value(password)
+
+    profile_path.write_text(
+        json.dumps(save_data, ensure_ascii=False, indent=2),
+        encoding='utf-8'
+    )


### PR DESCRIPTION
## Summary

- **安全修复**: 密码现在使用 Fernet 对称加密存储，不再明文保存
- **新增模块**: `secure_storage.py` 提供加密存储功能
- **自动迁移**: 现有明文密码会在首次加载时自动加密

## Changes

### 新增文件
- `secure_storage.py` - 安全存储模块
  - 使用 Fernet (AES-128-CBC) 对称加密
  - 密钥通过机器指纹派生（同一台机器稳定）
  - 自动迁移现有明文数据

### 修改文件
- `mcp_server.py` - 使用加密存储加载/保存配置
- `course_schedule.py` - 使用加密存储加载/保存配置
- `requirements.txt` - 添加 `cryptography>=41.0.0` 依赖

## Security Improvements

| Before | After |
|--------|-------|
| 密码明文存储在 `henu_profile.json` | 密码加密存储，带 `enc:` 前缀 |
| 任何人可直接读取密码文件 | 需要同一台机器才能解密 |
| 无密钥管理 | 密钥由机器指纹自动派生 |

## Test Plan

- [ ] 安装依赖: `pip install cryptography>=41.0.0`
- [ ] 运行 `setup_account` 保存新账号
- [ ] 检查 `henu_profile.json` 中密码字段有 `enc:` 前缀
- [ ] 重启后再次查询，确认密码能正确解密使用
- [ ] 验证现有明文密码自动迁移

🤖 Generated with [Claude Code](https://claude.com/claude-code)