### PR TITLE
perf: add TTL-based caching for runtime context and API queries

### DIFF
--- a/henu_plugin/cache.py
+++ b/henu_plugin/cache.py
@@ -1,0 +1,234 @@
+"""TTL-based cache for runtime context and API responses.
+
+Provides thread-safe caching with configurable TTL to reduce file I/O and API calls.
+"""
+from __future__ import annotations
+
+import time
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Callable, Generic, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass
+class CacheEntry(Generic[T]):
+    """A single cache entry with timestamp."""
+    value: T
+    created_at: float
+    ttl_seconds: float
+
+    def is_expired(self) -> bool:
+        """Check if entry has exceeded TTL."""
+        return time.time() - self.created_at > self.ttl_seconds
+
+
+class TTLCache(Generic[T]):
+    """Thread-safe TTL cache with automatic expiration."""
+
+    def __init__(
+        self,
+        default_ttl: float = 300.0,
+        max_size: int = 1000,
+        cleanup_interval: float = 60.0,
+    ):
+        """
+        Args:
+            default_ttl: Default TTL in seconds (default: 5 minutes)
+            max_size: Maximum number of entries before cleanup
+            cleanup_interval: Interval for automatic cleanup in seconds
+        """
+        self._cache: dict[str, CacheEntry[T]] = {}
+        self._lock = threading.RLock()
+        self._default_ttl = default_ttl
+        self._max_size = max_size
+        self._cleanup_interval = cleanup_interval
+        self._last_cleanup = time.time()
+
+    def get(self, key: str) -> T | None:
+        """Get cached value if not expired."""
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry is None:
+                return None
+            if entry.is_expired():
+                del self._cache[key]
+                return None
+            return entry.value
+
+    def set(
+        self,
+        key: str,
+        value: T,
+        ttl_seconds: float | None = None,
+    ) -> None:
+        """Set cached value with optional custom TTL."""
+        ttl = ttl_seconds if ttl_seconds is not None else self._default_ttl
+        with self._lock:
+            self._cache[key] = CacheEntry(
+                value=value,
+                created_at=time.time(),
+                ttl_seconds=ttl,
+            )
+            self._maybe_cleanup()
+
+    def delete(self, key: str) -> bool:
+        """Delete a specific cache entry."""
+        with self._lock:
+            if key in self._cache:
+                del self._cache[key]
+                return True
+            return False
+
+    def clear(self) -> None:
+        """Clear all cache entries."""
+        with self._lock:
+            self._cache.clear()
+
+    def invalidate_pattern(self, prefix: str) -> int:
+        """Invalidate all entries matching key prefix."""
+        with self._lock:
+            keys_to_delete = [
+                k for k in self._cache.keys() if k.startswith(prefix)
+            ]
+            for key in keys_to_delete:
+                del self._cache[key]
+            return len(keys_to_delete)
+
+    def _maybe_cleanup(self) -> None:
+        """Cleanup expired entries if interval elapsed or size exceeded."""
+        now = time.time()
+        if (
+            now - self._last_cleanup < self._cleanup_interval
+            and len(self._cache) < self._max_size
+        ):
+            return
+
+        self._last_cleanup = now
+        expired_keys = [
+            k for k, v in self._cache.items() if v.is_expired()
+        ]
+        for key in expired_keys:
+            del self._cache[key]
+
+        # If still over max_size, remove oldest entries
+        if len(self._cache) > self._max_size:
+            sorted_entries = sorted(
+                self._cache.items(),
+                key=lambda x: x[1].created_at,
+            )
+            entries_to_remove = len(self._cache) - self._max_size
+            for key, _ in sorted_entries[:entries_to_remove]:
+                del self._cache[key]
+
+    def get_or_compute(
+        self,
+        key: str,
+        compute_fn: Callable[[], T],
+        ttl_seconds: float | None = None,
+    ) -> T:
+        """Get cached value or compute and cache if missing/expired."""
+        cached = self.get(key)
+        if cached is not None:
+            return cached
+
+        value = compute_fn()
+        self.set(key, value, ttl_seconds)
+        return value
+
+    def stats(self) -> dict[str, Any]:
+        """Get cache statistics."""
+        with self._lock:
+            now = time.time()
+            expired = sum(1 for v in self._cache.values() if v.is_expired())
+            return {
+                "total_entries": len(self._cache),
+                "expired_entries": expired,
+                "valid_entries": len(self._cache) - expired,
+                "max_size": self._max_size,
+                "default_ttl": self._default_ttl,
+            }
+
+
+# Global cache instances with different TTL configurations
+
+# Runtime context cache: 5 minutes (account binding rarely changes)
+RUNTIME_CONTEXT_CACHE: TTLCache[dict[str, Any]] = TTLCache(
+    default_ttl=300.0,
+    max_size=500,
+)
+
+# Account context cache: 5 minutes
+ACCOUNT_CONTEXT_CACHE: TTLCache[dict[str, Any]] = TTLCache(
+    default_ttl=300.0,
+    max_size=500,
+)
+
+# Schedule data cache: 10 minutes (synced daily, rarely changes)
+SCHEDULE_CACHE: TTLCache[dict[str, Any]] = TTLCache(
+    default_ttl=600.0,
+    max_size=200,
+)
+
+# Library query cache: 2 minutes (reservation status changes frequently)
+LIBRARY_QUERY_CACHE: TTLCache[dict[str, Any]] = TTLCache(
+    default_ttl=120.0,
+    max_size=200,
+)
+
+# Seminar rooms cache: 5 minutes (availability changes moderately)
+SEMINAR_QUERY_CACHE: TTLCache[dict[str, Any]] = TTLCache(
+    default_ttl=300.0,
+    max_size=200,
+)
+
+# Server time cache: 30 seconds (needs frequent refresh)
+SERVER_TIME_CACHE: TTLCache[dict[str, Any]] = TTLCache(
+    default_ttl=30.0,
+    max_size=50,
+)
+
+
+def invalidate_user_cache(user_key: str) -> None:
+    """Invalidate all caches for a specific user."""
+    RUNTIME_CONTEXT_CACHE.invalidate_pattern(f"user:{user_key}:")
+    ACCOUNT_CONTEXT_CACHE.invalidate_pattern(f"user:{user_key}:")
+    SCHEDULE_CACHE.invalidate_pattern(f"user:{user_key}:")
+    LIBRARY_QUERY_CACHE.invalidate_pattern(f"user:{user_key}:")
+    SEMINAR_QUERY_CACHE.invalidate_pattern(f"user:{user_key}:")
+
+
+def invalidate_account_cache(user_key: str) -> None:
+    """Invalidate caches when account is updated."""
+    RUNTIME_CONTEXT_CACHE.invalidate_pattern(f"user:{user_key}:")
+    ACCOUNT_CONTEXT_CACHE.invalidate_pattern(f"user:{user_key}:")
+    SCHEDULE_CACHE.invalidate_pattern(f"user:{user_key}:")
+
+
+def invalidate_schedule_cache(user_key: str) -> None:
+    """Invalidate caches when schedule is synced."""
+    SCHEDULE_CACHE.invalidate_pattern(f"user:{user_key}:")
+    RUNTIME_CONTEXT_CACHE.delete(f"user:{user_key}:runtime_context")
+
+
+def clear_all_caches() -> None:
+    """Clear all global caches."""
+    RUNTIME_CONTEXT_CACHE.clear()
+    ACCOUNT_CONTEXT_CACHE.clear()
+    SCHEDULE_CACHE.clear()
+    LIBRARY_QUERY_CACHE.clear()
+    SEMINAR_QUERY_CACHE.clear()
+    SERVER_TIME_CACHE.clear()
+
+
+def get_cache_stats() -> dict[str, Any]:
+    """Get statistics for all caches."""
+    return {
+        "runtime_context": RUNTIME_CONTEXT_CACHE.stats(),
+        "account_context": ACCOUNT_CONTEXT_CACHE.stats(),
+        "schedule": SCHEDULE_CACHE.stats(),
+        "library": LIBRARY_QUERY_CACHE.stats(),
+        "seminar": SEMINAR_QUERY_CACHE.stats(),
+        "server_time": SERVER_TIME_CACHE.stats(),
+    }

--- a/henu_plugin/service.py
+++ b/henu_plugin/service.py
@@ -12,10 +12,23 @@ from langbot_plugin.api.entities.builtin.provider import session as provider_ses
 
 import course_schedule
 import mcp_server
+from henu_plugin.cache import (
+    ACCOUNT_CONTEXT_CACHE,
+    LIBRARY_QUERY_CACHE,
+    RUNTIME_CONTEXT_CACHE,
+    SCHEDULE_CACHE,
+    SEMINAR_QUERY_CACHE,
+    SERVER_TIME_CACHE,
+    get_cache_stats,
+    invalidate_account_cache,
+    invalidate_schedule_cache,
+    invalidate_user_cache,
+)
 from henu_plugin.cli import build_help_payload, build_next_commands, inspect_cli_command
 
 
 _RUNTIME_STATE_LOCK = threading.RLock()
+_CURRENT_IDENTITY: threading.local = threading.local()
 
 
 @dataclass(frozen=True)
@@ -106,13 +119,19 @@ class HenuPluginService:
         identity_hint: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         identity = self._resolve_identity(session, identity_hint=identity_hint or {})
+        cache_key = f"user:{identity.storage_key}:account_context"
+
+        cached = ACCOUNT_CONTEXT_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+
         paths = self._build_storage_paths(identity)
 
         try:
             with self._activate_user_storage(paths):
                 account_wrapper = mcp_server.show_account()
         except Exception as exc:
-            return {
+            result = {
                 "success": False,
                 "msg": f"读取账号绑定失败: {exc}",
                 "binding": {
@@ -124,13 +143,15 @@ class HenuPluginService:
                 },
                 "account": {},
             }
+            ACCOUNT_CONTEXT_CACHE.set(cache_key, result, ttl_seconds=60.0)
+            return result
 
         account = account_wrapper.get("account") if isinstance(account_wrapper, dict) else {}
         if not isinstance(account, dict):
             account = {}
 
         student_id = _text(account.get("student_id"))
-        return {
+        result = {
             "success": True,
             "binding": {
                 "qq": identity.qq,
@@ -149,16 +170,28 @@ class HenuPluginService:
                 "profile_file": _text(account.get("profile_file"), strip=False),
             },
         }
+        ACCOUNT_CONTEXT_CACHE.set(cache_key, result)
+        return result
 
     def get_time_snapshot(self, timezone: str = "Asia/Shanghai") -> dict[str, Any]:
+        cache_key = f"server_time:{timezone}"
+
+        cached = SERVER_TIME_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+
         snapshot = mcp_server.get_server_time(timezone=timezone)
         if not isinstance(snapshot, dict):
-            return {
+            result = {
                 "success": False,
                 "timezone": timezone,
                 "msg": "获取服务器时间失败",
             }
-        return snapshot
+        else:
+            result = snapshot
+
+        SERVER_TIME_CACHE.set(cache_key, result)
+        return result
 
     def get_runtime_context(
         self,
@@ -166,17 +199,30 @@ class HenuPluginService:
         identity_hint: dict[str, Any] | None = None,
         timezone: str = "Asia/Shanghai",
     ) -> dict[str, Any]:
+        identity = self._resolve_identity(session, identity_hint=identity_hint or {})
+        cache_key = f"user:{identity.storage_key}:runtime_context:{timezone}"
+
+        cached = RUNTIME_CONTEXT_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+
         account_context = self.get_sender_account_context(
             session,
             identity_hint=identity_hint,
         )
         server_time = self.get_time_snapshot(timezone=timezone)
-        return {
+        result = {
             "success": bool(account_context.get("success", True) and server_time.get("success", True)),
             "binding": account_context.get("binding") or {},
             "account": account_context.get("account") or {},
             "server_time": server_time,
         }
+        RUNTIME_CONTEXT_CACHE.set(cache_key, result)
+        return result
+
+    def get_cache_statistics(self) -> dict[str, Any]:
+        """Get cache statistics for monitoring."""
+        return get_cache_stats()
 
     def run_tool(
         self,
@@ -194,10 +240,25 @@ class HenuPluginService:
         paths = self._build_storage_paths(identity)
 
         try:
+            _CURRENT_IDENTITY.value = identity
             with self._activate_user_storage(paths):
                 result = handler(params or {})
         except Exception as exc:
             return {"success": False, "msg": f"{tool_name} 执行异常: {exc}"}
+        finally:
+            _CURRENT_IDENTITY.value = None
+
+        # Cache invalidation after successful writes
+        if isinstance(result, dict) and result.get("success"):
+            effective_tool = _text(result.get("_resolved_tool_name")) or tool_name
+            if effective_tool in {"setup_account"}:
+                invalidate_account_cache(identity.storage_key)
+            elif effective_tool in {"sync_schedule"}:
+                invalidate_schedule_cache(identity.storage_key)
+            elif effective_tool in {"library_reserve", "library_auto_signin", "library_cancel"}:
+                LIBRARY_QUERY_CACHE.invalidate_pattern(f"user:{identity.storage_key}:")
+            elif effective_tool in {"seminar_reserve", "seminar_signin", "seminar_cancel"}:
+                SEMINAR_QUERY_CACHE.invalidate_pattern(f"user:{identity.storage_key}:")
 
         if isinstance(result, dict):
             self._decorate_result(result, tool_name, identity, paths, query_id)
@@ -419,27 +480,68 @@ class HenuPluginService:
         )
 
     def _sync_schedule(self, params: dict[str, Any]) -> dict[str, Any]:
-        return mcp_server.sync_schedule(
+        result = mcp_server.sync_schedule(
             xn=_text(params.get("xn")) or None,
             xq=_text(params.get("xq")) or None,
             auto_calibrate=_bool(params.get("auto_calibrate"), True),
         )
+        # Invalidate schedule cache after sync
+        identity = getattr(_CURRENT_IDENTITY, "value", None)
+        if result.get("success") and identity:
+            SCHEDULE_CACHE.invalidate_pattern(f"user:{identity.storage_key}:")
+        return result
 
     def _schedule_query(self, params: dict[str, Any]) -> dict[str, Any]:
-        return mcp_server.schedule_query(
-            view=_text(params.get("view")) or "current",
-            timezone=_text(params.get("timezone")) or "Asia/Shanghai",
-            target_date=_text(params.get("target_date")),
+        identity = getattr(_CURRENT_IDENTITY, "value", None)
+        view = _text(params.get("view")) or "current"
+        timezone = _text(params.get("timezone")) or "Asia/Shanghai"
+        target_date = _text(params.get("target_date")) or ""
+
+        # Try cache for read-only views
+        if identity and view in {"current", "now", "week", "full"}:
+            cache_key = f"user:{identity.storage_key}:schedule:{view}:{target_date}"
+            cached = SCHEDULE_CACHE.get(cache_key)
+            if cached is not None:
+                return cached
+
+        result = mcp_server.schedule_query(
+            view=view,
+            timezone=timezone,
+            target_date=target_date,
             auto_calibrate=_bool(params.get("auto_calibrate"), True),
         )
 
+        # Cache successful read-only queries
+        if result.get("success") and identity and view in {"current", "now", "week", "full"}:
+            SCHEDULE_CACHE.set(cache_key, result)
+
+        return result
+
     def _library_query(self, params: dict[str, Any]) -> dict[str, Any]:
-        return mcp_server.library_query(
-            view=_text(params.get("view")) or "current",
-            record_type=_text(params.get("record_type")) or "1",
-            page=_int(params.get("page"), 1),
+        identity = getattr(_CURRENT_IDENTITY, "value", None)
+        view = _text(params.get("view")) or "current"
+        record_type = _text(params.get("record_type")) or "1"
+        page = _int(params.get("page"), 1)
+
+        # Try cache for read operations
+        if identity:
+            cache_key = f"user:{identity.storage_key}:library:{view}:{record_type}:{page}"
+            cached = LIBRARY_QUERY_CACHE.get(cache_key)
+            if cached is not None:
+                return cached
+
+        result = mcp_server.library_query(
+            view=view,
+            record_type=record_type,
+            page=page,
             limit=_int(params.get("limit"), 20),
         )
+
+        # Cache successful queries
+        if result.get("success") and identity:
+            LIBRARY_QUERY_CACHE.set(cache_key, result)
+
+        return result
 
     def _library_reserve(self, params: dict[str, Any]) -> dict[str, Any]:
         return mcp_server.library_reserve(
@@ -469,9 +571,21 @@ class HenuPluginService:
         )
 
     def _seminar_query(self, params: dict[str, Any]) -> dict[str, Any]:
-        return mcp_server.seminar_query(
-            view=_text(params.get("view")) or "rooms",
-            target_date=_text(params.get("target_date")),
+        identity = getattr(_CURRENT_IDENTITY, "value", None)
+        view = _text(params.get("view")) or "rooms"
+        target_date = _text(params.get("target_date")) or ""
+        page = _int(params.get("page"), 1)
+
+        # Try cache for read operations
+        if identity and view in {"rooms", "filters", "detail"}:
+            cache_key = f"user:{identity.storage_key}:seminar:{view}:{target_date}:{page}"
+            cached = SEMINAR_QUERY_CACHE.get(cache_key)
+            if cached is not None:
+                return cached
+
+        result = mcp_server.seminar_query(
+            view=view,
+            target_date=target_date,
             members=_int(params.get("members"), 0),
             name=_text(params.get("name")),
             room=_text(params.get("room")),
@@ -485,13 +599,19 @@ class HenuPluginService:
             category_names=_text(params.get("category_names")),
             boutique_ids=_text(params.get("boutique_ids")),
             boutique_names=_text(params.get("boutique_names")),
-            page=_int(params.get("page"), 1),
+            page=page,
             area_id=_text(params.get("area_id")),
             record_type=_text(params.get("record_type")) or "1",
             limit=_int(params.get("limit"), 20),
             mode=_text(params.get("mode")) or "books",
             status=_text(params.get("status")),
         )
+
+        # Cache successful queries
+        if result.get("success") and identity and view in {"rooms", "filters", "detail"}:
+            SEMINAR_QUERY_CACHE.set(cache_key, result)
+
+        return result
 
     def _seminar_reserve(self, params: dict[str, Any]) -> dict[str, Any]:
         return mcp_server.seminar_reserve(


### PR DESCRIPTION
## Summary
- Add `cache.py` module with thread-safe TTL cache implementation
- Cache runtime context, account context, and server time with 5min TTL
- Cache schedule queries with 10min TTL (synced daily)
- Cache library queries with 2min TTL (status changes frequently)
- Cache seminar queries with 5min TTL
- Auto-invalidate caches on successful write operations
- Add `get_cache_statistics()` for monitoring

## Performance Improvements
| Scenario | Before | After |
|----------|--------|-------|
| Repeated schedule queries | File I/O each time | Cache hit, no I/O |
| Concurrent multi-user access | Repeated profile reads | Cache reuse |
| Library status polling | API call each time | Reuse within 2min |

## Cache Configuration
```
Cache Type       | TTL   | Purpose
-----------------|-------|---------------------------
RUNTIME_CONTEXT  | 5min  | User account binding info
ACCOUNT_CONTEXT  | 5min  | Account details
SCHEDULE_CACHE   | 10min | Course schedule (synced daily)
LIBRARY_QUERY    | 2min  | Library reservation status
SEMINAR_QUERY    | 5min  | Seminar room queries
SERVER_TIME      | 30s   | Server time (frequent refresh)
```

## Cache Invalidation
| Operation | Invalidated Caches |
|-----------|-------------------|
| setup_account | account + runtime + schedule |
| sync_schedule | schedule |
| library_reserve/signin/cancel | library |
| seminar_reserve/signin/cancel | seminar |

🤖 Generated with [Claude Code](https://claude.com/claude-code)