### PR TITLE
图书馆区域/座位查询改为真实 /v4 数据，并补充预约后核对

### DIFF
--- a/henu_plugin/cli.py
+++ b/henu_plugin/cli.py
@@ -169,7 +169,8 @@ def build_help_payload(topic: str) -> dict[str, Any]:
             "topic": normalized,
             "summary": "图书馆查询、预约、签到、取消。",
             "commands": [
-                "library locations",
+                "library locations [--date YYYY-MM-DD]",
+                "library seats --area-id <ID> [--date YYYY-MM-DD] [--time HH:MM]",
                 "library current",
                 "library records [--record-type 1] [--page 1] [--limit 20]",
                 "library reserve [--location <区域>] [--seat-no <座位>] [--date YYYY-MM-DD] [--time HH:MM]",
@@ -177,10 +178,13 @@ def build_help_payload(topic: str) -> dict[str, Any]:
                 "library cancel --record-id <ID> [--record-type auto]",
             ],
             "examples": [
+                "library locations --date 2026-03-30",
+                "library seats --area-id 12 --date 2026-03-30 --time 06:30",
                 "library current",
                 "library reserve --location 金明馆北区 --seat-no 201 --date 2026-03-30",
             ],
             "tips": [
+                "预约前先查真实区域和座位，不要凭旧名称或旧 area_id 预约。",
                 "先用 `library current` 或 `library records` 看现状。",
                 "取消与签到属于真实写操作，只认 `success=true`。",
             ],
@@ -309,7 +313,9 @@ def build_next_commands(spec: CliCommandSpec, result: dict[str, Any] | None = No
         return ["schedule day --date 2026-03-30", "schedule week"]
     if resolved_tool == "library_query":
         if spec.params.get("view") == "locations":
-            return ["library reserve --location <区域> --seat-no <座位> --date YYYY-MM-DD"]
+            return ["library seats --area-id <ID> --date YYYY-MM-DD --time HH:MM", "library reserve --location <区域> --seat-no <座位> --date YYYY-MM-DD"]
+        if spec.params.get("view") == "seats":
+            return ["library reserve --location <区域或area_id> --seat-no <座位> --date YYYY-MM-DD --time HH:MM"]
         return ["library current", "library records"]
     if resolved_tool == "library_reserve":
         return ["library current", "library signin"] if success else ["library locations", "library current"]
@@ -496,8 +502,28 @@ def _parse_library(raw: str, argv: tuple[str, ...]) -> CliCommandSpec:
             raw=raw,
             argv=argv,
             resolved_tool="library_query",
-            params={"view": "locations"},
+            params={
+                "view": "locations",
+                "target_date": _string_option(options, "date") or _string_option(options, "target_date"),
+            },
             action="library locations",
+            should_preload_runtime_context=True,
+        )
+    if sub in {"seats", "seat"}:
+        area_id = _string_option(options, "area_id") or _string_option(options, "area-id")
+        if not area_id:
+            return _error_spec(raw, "缺少参数 `--area-id`。", help_topic="library")
+        return CliCommandSpec(
+            raw=raw,
+            argv=argv,
+            resolved_tool="library_query",
+            params={
+                "view": "seats",
+                "area_id": area_id,
+                "target_date": _string_option(options, "date") or _string_option(options, "target_date"),
+                "preferred_time": _string_option(options, "time") or _string_option(options, "preferred_time") or "08:00",
+            },
+            action="library seats",
             should_preload_runtime_context=True,
         )
     if sub in {"current", "now"}:

--- a/henu_plugin/service.py
+++ b/henu_plugin/service.py
@@ -593,18 +593,24 @@ class HenuPluginService:
     def _library_query(self, params: dict[str, Any]) -> dict[str, Any]:
         identity = getattr(_CURRENT_IDENTITY, "value", None)
         view = _text(params.get("view")) or "current"
+        target_date = _text(params.get("target_date"))
+        area_id = _text(params.get("area_id"))
+        preferred_time = _text(params.get("preferred_time")) or "08:00"
         record_type = _text(params.get("record_type")) or "1"
         page = _int(params.get("page"), 1)
 
         # Try cache for read operations
         if identity:
-            cache_key = f"user:{identity.storage_key}:library:{view}:{record_type}:{page}"
+            cache_key = f"user:{identity.storage_key}:library:{view}:{target_date}:{area_id}:{preferred_time}:{record_type}:{page}"
             cached = LIBRARY_QUERY_CACHE.get(cache_key)
             if cached is not None:
                 return cached
 
         result = mcp_server.library_query(
             view=view,
+            target_date=target_date,
+            area_id=area_id,
+            preferred_time=preferred_time,
             record_type=record_type,
             page=page,
             limit=_int(params.get("limit"), 20),
@@ -612,7 +618,8 @@ class HenuPluginService:
 
         # Cache successful queries
         if result.get("success") and identity:
-            LIBRARY_QUERY_CACHE.set(cache_key, result)
+            ttl = 20.0 if view == "seats" else 60.0 if view == "locations" else None
+            LIBRARY_QUERY_CACHE.set(cache_key, result, ttl_seconds=ttl)
 
         return result
 

--- a/library_core/henu_core.py
+++ b/library_core/henu_core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import datetime as dt
 import json
@@ -6,6 +8,7 @@ import random
 import re
 from html import unescape
 from typing import Any
+from urllib.parse import urljoin, urlsplit, urlunsplit, parse_qsl, urlencode
 
 import requests
 from Crypto.Cipher import AES
@@ -199,6 +202,18 @@ class HenuLibraryBot:
         return match.group(1) if match else ""
 
     @staticmethod
+    def _redact_ticket_url(url: str) -> str:
+        try:
+            parts = urlsplit(str(url or ""))
+            query = urlencode(
+                [(key, "[redacted]" if key in {"cas", "ticket"} else value) for key, value in parse_qsl(parts.query, keep_blank_values=True)]
+            )
+            fragment = re.sub(r"((?:cas|ticket)=)[^&#]+", r"\1[redacted]", parts.fragment)
+            return urlunsplit((parts.scheme, parts.netloc, parts.path, query, fragment))
+        except Exception:
+            return re.sub(r"((?:cas|ticket)=)[^&#]+", r"\1[redacted]", str(url or ""))
+
+    @staticmethod
     def _extract_cas_login_error(html_text: str) -> str:
         text = str(html_text or "")
         if not text:
@@ -300,6 +315,51 @@ class HenuLibraryBot:
         self._set_last_error("")
         return True
 
+    def _open_cas_flow(
+        self,
+        url: str,
+        method: str = "GET",
+        **kwargs: Any,
+    ) -> tuple[str, requests.Response]:
+        """Follow CAS redirects manually so ticket/cas in Location is not missed."""
+        current_url = str(url)
+        current_method = method.upper()
+        request_kwargs = dict(kwargs)
+        response: requests.Response | None = None
+
+        for _ in range(10):
+            response = self.session.request(
+                current_method,
+                current_url,
+                allow_redirects=False,
+                timeout=int(request_kwargs.pop("timeout", 25)),
+                **request_kwargs,
+            )
+            direct_ticket = self._extract_cas_ticket(response.url)
+            if direct_ticket:
+                return direct_ticket, response
+
+            if response.status_code not in {301, 302, 303, 307, 308}:
+                return "", response
+
+            location = response.headers.get("Location") or response.headers.get("location") or ""
+            if not location:
+                return "", response
+            next_url = urljoin(current_url, location)
+            redirect_ticket = self._extract_cas_ticket(next_url)
+            if redirect_ticket:
+                return redirect_ticket, response
+
+            current_url = next_url
+            if response.status_code == 303 or (response.status_code == 302 and current_method == "POST"):
+                current_method = "GET"
+                request_kwargs.pop("data", None)
+                request_kwargs.pop("json", None)
+
+        if response is None:
+            raise RuntimeError("CAS 请求未执行")
+        return "", response
+
     def _is_token_valid(self) -> bool:
         if not self.token:
             return False
@@ -332,8 +392,7 @@ class HenuLibraryBot:
         try:
             # 2) 先尝试 TGT 免密跳转
             try:
-                resp = self.session.get(cas_auth_url, allow_redirects=True, timeout=25)
-                cas_ticket = self._extract_cas_ticket(resp.url)
+                cas_ticket, resp = self._open_cas_flow(cas_auth_url, method="GET")
                 if cas_ticket and self._exchange_cas_ticket(cas_ticket):
                     return True
             except Exception as exc:
@@ -376,10 +435,17 @@ class HenuLibraryBot:
                 login_resp = self.session.post(
                     login_page.url,
                     data=form_data,
-                    allow_redirects=True,
                     timeout=25,
+                    allow_redirects=False,
                 )
                 cas_ticket = self._extract_cas_ticket(login_resp.url)
+                if not cas_ticket and login_resp.status_code in {301, 302, 303, 307, 308}:
+                    location = login_resp.headers.get("Location") or login_resp.headers.get("location") or ""
+                    if location:
+                        next_url = urljoin(login_page.url, location)
+                        cas_ticket = self._extract_cas_ticket(next_url)
+                        if not cas_ticket:
+                            cas_ticket, login_resp = self._open_cas_flow(next_url, method="GET")
                 if not cas_ticket:
                     page_error = self._extract_cas_login_error(login_resp.text)
                     if page_error:
@@ -389,7 +455,7 @@ class HenuLibraryBot:
                     else:
                         # 提供更详细的错误信息，包括最终 URL
                         final_url = str(login_resp.url or "")
-                        url_hint = f"，最终 URL: {final_url[:200]}" if final_url else ""
+                        url_hint = f"，最终 URL: {self._redact_ticket_url(final_url)[:200]}" if final_url else ""
                         self._set_last_error(f"CAS 登录未返回 ticket{url_hint}")
                     return False
                 return self._exchange_cas_ticket(cas_ticket)
@@ -505,11 +571,156 @@ class HenuLibraryBot:
             return "signin"
         return ""
 
+    @staticmethod
+    def _area_display_name(area: dict[str, Any]) -> str:
+        return str(area.get("nameMerge") or area.get("name_merge") or area.get("name") or area.get("enname") or "").strip()
+
+    @staticmethod
+    def _collect_area_rows(value: Any) -> list[dict[str, Any]]:
+        if isinstance(value, list):
+            rows: list[dict[str, Any]] = []
+            for item in value:
+                rows.extend(HenuLibraryBot._collect_area_rows(item))
+            return rows
+        if not isinstance(value, dict):
+            return []
+
+        rows = []
+        if value.get("id") and (value.get("name") or value.get("nameMerge") or value.get("name_merge") or value.get("enname")):
+            rows.append(value)
+        for key in ("area", "list", "children", "child", "data"):
+            if key in value:
+                rows.extend(HenuLibraryBot._collect_area_rows(value.get(key)))
+
+        seen: set[str] = set()
+        unique: list[dict[str, Any]] = []
+        for row in rows:
+            area_id = str(row.get("id") or "").strip()
+            if not area_id or area_id in seen:
+                continue
+            seen.add(area_id)
+            unique.append(row)
+        return unique
+
+    @staticmethod
+    def _normalize_area_row(area: dict[str, Any], premises: list[dict[str, Any]], storey: list[dict[str, Any]]) -> dict[str, Any]:
+        premise_by_id = {
+            str(item.get("id") or ""): str(item.get("name") or item.get("enname") or "").strip()
+            for item in premises
+            if isinstance(item, dict)
+        }
+        storey_by_id = {
+            str(item.get("id") or ""): item
+            for item in storey
+            if isinstance(item, dict)
+        }
+        area_name = HenuLibraryBot._area_display_name(area)
+        storey_row = storey_by_id.get(str(area.get("parentId") or area.get("parent_id") or ""))
+        if not isinstance(storey_row, dict):
+            storey_row = {}
+        name_parts = [part.strip() for part in re.split(r"[-/｜|>]", area_name) if part.strip()]
+        campus = (
+            premise_by_id.get(str(area.get("topId") or area.get("top_id") or ""))
+            or premise_by_id.get(str(storey_row.get("parentId") or storey_row.get("topId") or ""))
+            or (name_parts[0] if name_parts else "")
+        )
+        floor = str(storey_row.get("name") or area.get("floor") or (name_parts[1] if len(name_parts) > 1 else "") or "").strip()
+        return {
+            "location": area_name,
+            "area_id": str(area.get("id") or "").strip(),
+            "name": area_name,
+            "short_name": str(area.get("name") or area.get("enname") or "").strip(),
+            "campus": campus,
+            "floor": floor,
+            "free_num": area.get("free_num", area.get("freeNum")),
+            "total_num": area.get("total_num", area.get("totalNum")),
+            "raw": area,
+        }
+
+    @staticmethod
+    def _normalize_seat_row(seat: dict[str, Any]) -> dict[str, Any]:
+        status = str(seat.get("status") or "")
+        seat_no = str(seat.get("no") or seat.get("name") or "").strip()
+        in_label = str(seat.get("in_label", "1")) == "1"
+        status_text = str(seat.get("status_name") or seat.get("statusName") or "").strip()
+        if not status_text:
+            if status == "1":
+                status_text = "可预约"
+            elif status == "2":
+                status_text = "已占用"
+            elif status == "3":
+                status_text = "不可用"
+            else:
+                status_text = status or "未知"
+        return {
+            "seat_id": str(seat.get("id") or "").strip(),
+            "seat_no": seat_no,
+            "name": str(seat.get("name") or seat_no).strip(),
+            "status": status,
+            "status_text": status_text,
+            "available": status == "1" and in_label,
+            "in_label": in_label,
+            "layout": {
+                "x": seat.get("point_x"),
+                "y": seat.get("point_y"),
+                "width": seat.get("width"),
+                "height": seat.get("height"),
+            },
+            "raw": seat,
+        }
+
+    @staticmethod
+    def _safe_confirm_payload(payload: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in payload.items()
+            if key in {"seat_id", "segment", "day", "start_time", "end_time", "begdate", "enddate"}
+        }
+
     def _fetch_pick_areas(self, target_date: str) -> list[dict[str, Any]]:
         resp = self._post_json("/v4/space/pick", {"date": target_date})
         if resp.get("code") != 0:
             raise RuntimeError(self._resp_msg(resp, "获取区域列表失败"))
-        return ((resp.get("data") or {}).get("area") or [])
+        data = resp.get("data") or {}
+        if isinstance(data, dict):
+            return self._collect_area_rows(data.get("area") or data)
+        return self._collect_area_rows(data)
+
+    def list_library_locations(self, target_date: str = "") -> dict[str, Any]:
+        if not self._is_token_valid() and not self.login():
+            return self._login_failed_result({"locations": []})
+
+        query_date = str(target_date or "").strip() or _now_dt().strftime("%Y-%m-%d")
+        try:
+            dt.date.fromisoformat(query_date)
+        except ValueError:
+            return {"success": False, "msg": "target_date 格式必须为 YYYY-MM-DD", "date": query_date, "locations": []}
+
+        try:
+            resp = self._post_json("/v4/space/pick", {"date": query_date})
+            if resp.get("code") != 0:
+                return {"success": False, "msg": self._resp_msg(resp, "获取区域列表失败"), "date": query_date, "locations": []}
+            data = resp.get("data") or {}
+            data_dict = data if isinstance(data, dict) else {}
+            raw_areas = self._collect_area_rows(data_dict.get("area") or data)
+            premises = data_dict.get("premises") if isinstance(data_dict.get("premises"), list) else []
+            storey = data_dict.get("storey") if isinstance(data_dict.get("storey"), list) else []
+            locations = [
+                self._normalize_area_row(area, premises, storey)
+                for area in raw_areas
+                if isinstance(area, dict)
+            ]
+            return {
+                "success": True,
+                "msg": self._resp_msg(resp, "操作成功"),
+                "date": query_date,
+                "locations": locations,
+                "total": len(locations),
+                "premises": premises,
+                "storey": storey,
+            }
+        except Exception as exc:
+            return {"success": False, "msg": f"查询图书馆区域异常: {exc}", "date": query_date, "locations": []}
 
     def _resolve_area(self, location_name: str, target_date: str) -> tuple[str, str]:
         location = str(location_name or "").strip()
@@ -519,19 +730,20 @@ class HenuLibraryBot:
         if location.isdigit():
             return location, location
 
-        if location in self.LOCATIONS:
-            return str(self.LOCATIONS[location]), location
-
         areas = self._fetch_pick_areas(target_date)
 
         for area in areas:
-            if location == str(area.get("name", "")).strip():
-                return str(area.get("id")), str(area.get("name"))
+            area_name = self._area_display_name(area)
+            if location == area_name or location == str(area.get("name", "")).strip():
+                return str(area.get("id")), area_name
 
         for area in areas:
-            area_name = str(area.get("name", "")).strip()
+            area_name = self._area_display_name(area)
             if location and (location in area_name or area_name in location):
                 return str(area.get("id")), area_name
+
+        if location in self.LOCATIONS:
+            return str(self.LOCATIONS[location]), location
 
         raise RuntimeError(f"区域 '{location}' 未找到，请检查名称")
 
@@ -741,6 +953,49 @@ class HenuLibraryBot:
         if resp.get("code") != 0:
             raise RuntimeError(self._resp_msg(resp, "查询座位失败"))
         return ((resp.get("data") or {}).get("list") or [])
+
+    def list_library_seats(
+        self,
+        area_id: str,
+        target_date: str = "",
+        preferred_time: str | None = None,
+    ) -> dict[str, Any]:
+        area_text = str(area_id or "").strip()
+        if not area_text:
+            return {"success": False, "msg": "area_id 不能为空", "seats": []}
+        if not self._is_token_valid() and not self.login():
+            return self._login_failed_result({"seats": []})
+
+        query_date = str(target_date or "").strip() or _now_dt().strftime("%Y-%m-%d")
+        try:
+            dt.date.fromisoformat(query_date)
+        except ValueError:
+            return {"success": False, "msg": "target_date 格式必须为 YYYY-MM-DD", "seats": []}
+
+        try:
+            space_map = self._get_space_map(area_text)
+            plan = self._build_reservation_plan(area_text, space_map, query_date, preferred_time=preferred_time)
+            seats = self._query_seats(plan["seat_query"])
+            area_name = self._area_display_name(space_map) or area_text
+            return {
+                "success": True,
+                "msg": "操作成功",
+                "date": query_date,
+                "area": {
+                    "area_id": area_text,
+                    "area_name": area_name,
+                    "reserve_type": plan.get("reserve_type", ""),
+                    "space_type": plan.get("space_type", ""),
+                },
+                "seat_query": plan.get("seat_query") or {},
+                "confirm_path": plan.get("confirm_path", ""),
+                "confirm_payload_preview": self._safe_confirm_payload(plan.get("confirm_payload") or {}),
+                "map": space_map,
+                "seats": [self._normalize_seat_row(seat) for seat in seats if isinstance(seat, dict)],
+                "total": len(seats),
+            }
+        except Exception as exc:
+            return {"success": False, "msg": f"查询图书馆座位异常: {exc}", "date": query_date, "area_id": area_text, "seats": []}
 
     def _find_target_seat(self, seats: list[dict[str, Any]], seat_no: str) -> dict[str, Any] | None:
         target_raw = str(seat_no).strip()
@@ -1441,9 +1696,25 @@ class HenuLibraryBot:
                 is_crypto=bool(plan.get("confirm_crypto")),
             )
             success = confirm_resp.get("code") == 0
+            current_result = self.list_current_appointments() if success else {"success": False, "appointments": []}
+            current_appointments = current_result.get("appointments") if isinstance(current_result, dict) else []
+            if not isinstance(current_appointments, list):
+                current_appointments = []
+            normalized_target = self._normalize_seat_row(target_seat)
             return {
                 "success": success,
                 "msg": self._resp_msg(confirm_resp),
+                "code": confirm_resp.get("code"),
+                "area": {
+                    "area_id": str(area_id),
+                    "area_name": area_name,
+                },
+                "seat": {
+                    "seat_id": normalized_target.get("seat_id", ""),
+                    "seat_no": normalized_target.get("seat_no", ""),
+                    "status": normalized_target.get("status", ""),
+                    "status_text": normalized_target.get("status_text", ""),
+                },
                 "applied_time": {
                     "preferred_time": plan.get("preferred_time", ""),
                     "start_time": (plan.get("seat_query") or {}).get("start_time", ""),
@@ -1451,6 +1722,11 @@ class HenuLibraryBot:
                     "reserve_type": plan.get("reserve_type", ""),
                     "space_type": plan.get("space_type", ""),
                 },
+                "seat_query": plan.get("seat_query") or {},
+                "confirm_path": plan.get("confirm_path", ""),
+                "confirm_payload_preview": self._safe_confirm_payload(confirm_payload),
+                "current_appointments": current_appointments,
+                "current_appointments_total": len(current_appointments),
             }
         except Exception as exc:
             return {"success": False, "msg": f"预约流程异常: {exc}"}

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2053,20 +2053,58 @@ def list_output_files(limit: int = 20) -> list[dict[str, Any]]:
     ]
 
 
-def _library_locations_impl() -> dict[str, Any]:
+def _library_locations_impl(target_date: str = "") -> dict[str, Any]:
     """
     【必须调用】查看图书馆区域列表 - 获取所有可预约的图书馆区域
 
-    功能：返回图书馆所有区域的名称和ID
+    功能：调用真实 /v4/space/pick 返回目标日期图书馆所有区域的名称和ID
 
     重要：不要编造区域信息，必须调用此工具获取准确的区域列表。
     """
     if HenuLibraryBot is None:
         return {"success": False, "msg": f"图书馆核心模块不可用: {LIBRARY_CORE_EXPECTED_FILE}", "locations": []}
-    return {"success": True, "locations": [
-        {"location": name, "area_id": str(area_id)} 
-        for name, area_id in HenuLibraryBot.LOCATIONS.items()
-    ]}
+
+    profile = load_json(PROFILE_FILE)
+    sid, pwd = str(profile.get("student_id", "")), str(profile.get("password", ""))
+    if not sid or not pwd:
+        return {"success": False, "msg": "缺少账号", "locations": []}
+
+    bot = _build_library_bot(sid, pwd)
+    if not bot:
+        return _library_login_failed({"locations": []})
+
+    result = bot.list_library_locations(target_date=str(target_date or "").strip())
+    _save_library_cookies(bot.get_cookies())
+    return result
+
+
+def _library_seats_impl(area_id: str = "", target_date: str = "", preferred_time: str = "08:00") -> dict[str, Any]:
+    """
+    查询某个图书馆区域的真实座位列表和座位图原始数据。
+    """
+    if HenuLibraryBot is None:
+        return {"success": False, "msg": "图书馆模块不可用", "seats": []}
+
+    area_text = str(area_id or "").strip()
+    if not area_text:
+        return {"success": False, "msg": "area_id 不能为空", "seats": []}
+
+    profile = load_json(PROFILE_FILE)
+    sid, pwd = str(profile.get("student_id", "")), str(profile.get("password", ""))
+    if not sid or not pwd:
+        return {"success": False, "msg": "缺少账号", "seats": []}
+
+    bot = _build_library_bot(sid, pwd)
+    if not bot:
+        return _library_login_failed({"seats": []})
+
+    result = bot.list_library_seats(
+        area_id=area_text,
+        target_date=str(target_date or "").strip(),
+        preferred_time=str(preferred_time or "08:00"),
+    )
+    _save_library_cookies(bot.get_cookies())
+    return result
 
 
 def _library_reserve_impl(
@@ -2726,6 +2764,9 @@ def sync_schedule(
 @mcp.tool()
 def library_query(
     view: str = "current",
+    target_date: str = "",
+    area_id: str = "",
+    preferred_time: str = "08:00",
     record_type: str = "1",
     page: int = 1,
     limit: int = 20,
@@ -2734,23 +2775,26 @@ def library_query(
     统一查询图书馆信息。
 
     view:
-    - locations: 图书馆区域列表
+    - locations: 目标日期真实图书馆区域列表，来自 /v4/space/pick
+    - seats: 某区域真实座位列表和座位图原始数据，来自 /v4/Space/map + /v4/Space/seat
     - current: 当前预约
     - records: 历史预约记录
 
     规则：
     1) 查询 `current` 或 `records` 前必须先调用 `system_status` 确认当前日期时间。
-    2) 预约前应先查询 `locations`，不得凭记忆列举区域。
+    2) 预约前应先查询 `locations` 和 `seats`，不得凭记忆列举区域/座位。
     3) 回复仅可基于本次返回结果，不得编造。
     """
     normalized_view = str(view or "current").strip().lower()
     if normalized_view == "locations":
-        return _library_locations_impl()
+        return _library_locations_impl(target_date=target_date)
+    if normalized_view == "seats":
+        return _library_seats_impl(area_id=area_id, target_date=target_date, preferred_time=preferred_time)
     if normalized_view == "current":
         return _library_current_impl()
     if normalized_view == "records":
         return _library_records_impl(record_type=record_type, page=page, limit=limit)
-    return {"success": False, "msg": "view 仅支持 locations/current/records"}
+    return {"success": False, "msg": "view 仅支持 locations/seats/current/records"}
 
 
 @mcp.tool()
@@ -2765,7 +2809,7 @@ def library_reserve(
     
     【执行协议（必须遵守）】
     1) 禁止在未调用工具时说“已预约成功/已帮你预约”。
-    2) 回复必须包含本次返回的 success/msg/date（以及 applied_time 如有）。
+    2) 回复必须包含本次返回的 success/msg/date（以及 area/seat/applied_time/current_appointments 如有）。
     3) 调用失败时必须原样转述失败原因，不得改写为成功。
     
     功能：向图书馆系统提交座位预约请求


### PR DESCRIPTION
Closes #10

整理与验证：©️生🐟

#### 背景

当前图书馆预约站点的区域、楼层、座位和开放时间都依赖实时 `/v4` 接口返回。旧的静态 `LOCATIONS` 容易在区域调整后变成过期映射，导致用户以为选择了某个区域，但实际提交了另一个 `area_id`。另外，预约接口提交成功后如果不立刻查当前预约，也很难核对真实订到的位置。

#### 改动

- `library_query(view="locations")` 改为登录后真实调用 `/v4/space/pick`，支持 `target_date`，返回 `area_id`、完整区域名、校区、楼层、剩余/总座位数和原始字段。
- 新增 `library_query(view="seats", area_id=..., target_date=..., preferred_time=...)`，组合 `/v4/Space/map` 与 `/v4/Space/seat` 返回真实座位列表、真实 `seat_id`、状态、坐标字段、座位查询参数和预约 payload 预览。
- CAS 登录/刷新 token 改为手动处理 301/302/303 跳转，检查每一步 `Location` 中的 `ticket/cas`，同时兼容图书馆前端 `#/cas/?cas=...` 形态，避免自动跳转后丢失 ticket 线索。
- CAS 失败时输出脱敏后的最终 URL，不暴露真实 ticket/cas。
- 预约解析区域时优先用当天 `/v4/space/pick` 的真实区域数据，静态 `LOCATIONS` 只保留为兼容兜底。
- `reserve()` 提交预约后，如果接口成功，会立即调用 `/v4/index/subscribe`，把当前预约列表放入结果，便于核对实际订到的区域/座位。
- 保留现有 AES 逻辑，并用离线断言覆盖 CAS 密码加密与图书馆业务 `aesjson` 加密可正常产出 base64 密文；本次不重写已和官网一致的 AES 算法。
- 补上 `from __future__ import annotations`，修复 README 声明的 Python 3.9+ 环境下导入 `dict[str, Any] | None` 会失败的问题。
- Langbot CLI 增加：
  - `library locations --date YYYY-MM-DD`
  - `library seats --area-id <ID> --date YYYY-MM-DD --time HH:MM`
- Langbot 查询缓存 key 纳入日期、区域和时间；区域短缓存 60 秒，座位短缓存 20 秒，避免跨日期/跨区域串结果。

#### 验证

- `.venv/bin/python -m py_compile library_core/henu_core.py mcp_server.py henu_plugin/service.py henu_plugin/cli.py`
- 离线 helper 冒烟：CAS ticket/cas 提取、ticket URL 脱敏、AES 加密 base64 输出、区域递归提取、区域归一化、座位归一化、CLI 解析 `library locations` 和 `library seats`。
- 隐私扫描未发现真实 token、CASTGC、Authorization、Bearer、CAS ticket。

#### 注意

- 本 PR 不包含任何账号、密码、token、CASTGC、cookie 或真实预约记录。
- 真实接口调用仍需要用户本地配置自己的河南大学账号后执行。
- 本地 Python 3.9 的 `urllib3` 会提示 LibreSSL warning，不影响本次离线 helper 和编译验证。
