### PR TITLE
Fix library result contracts and retry parsing

### DIFF
--- a/campus_core/resource_registry/__init__.py
+++ b/campus_core/resource_registry/__init__.py
@@ -28,6 +28,8 @@ from .registry import (
 from .resolver import resolve_resource
 from .seed import preload_seed_if_needed
 from .sync import (
+    normalize_library_location,
+    normalize_library_seat,
     sync_classrooms_from_metadata,
     sync_library_resources,
     sync_seminar_resources,
@@ -56,6 +58,8 @@ __all__ = [
     # Resolver
     "resolve_resource",
     # Sync
+    "normalize_library_location",
+    "normalize_library_seat",
     "sync_classrooms_from_metadata",
     "sync_library_resources",
     "sync_seminar_resources",

--- a/campus_core/resource_registry/sync.py
+++ b/campus_core/resource_registry/sync.py
@@ -26,6 +26,40 @@ def _now_iso() -> str:
     return datetime.now().isoformat()
 
 
+def _first_text(data: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = data.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return ""
+
+
+def normalize_library_location(location: dict[str, Any]) -> tuple[str, str]:
+    """Return the canonical area ID and name from a library location DTO."""
+    if not isinstance(location, dict):
+        return "", ""
+    return (
+        _first_text(location, "areaId", "area_id", "id"),
+        _first_text(location, "areaName", "area_name", "name", "location"),
+    )
+
+
+def normalize_library_seat(
+    seat: dict[str, Any],
+    fallback_area_id: str = "",
+) -> tuple[str, str]:
+    """Return the canonical seat number and area ID from a seat DTO."""
+    if not isinstance(seat, dict):
+        return "", str(fallback_area_id or "").strip()
+    return (
+        _first_text(seat, "seatNo", "seat_no", "no", "name"),
+        _first_text(seat, "areaId", "area_id") or str(fallback_area_id or "").strip(),
+    )
+
+
 # ── 教室同步 ──────────────────────────────────────────────
 
 
@@ -172,10 +206,12 @@ def sync_library_resources(
     synced = 0
 
     library_id = "henu_library"  # 河南大学图书馆统一 ID
+    fallback_area_id = ""
+    if len(locations) == 1:
+        fallback_area_id, _ = normalize_library_location(locations[0])
 
     for loc in locations:
-        area_id = str(loc.get("areaId", loc.get("area_id", loc.get("id", ""))))
-        area_name = str(loc.get("areaName", loc.get("area_name", loc.get("name", ""))))
+        area_id, area_name = normalize_library_location(loc)
         if not area_id or not area_name:
             continue
 
@@ -196,8 +232,7 @@ def sync_library_resources(
 
     if seats:
         for seat in seats:
-            seat_no = str(seat.get("seatNo", seat.get("seat_no", seat.get("name", ""))))
-            area_id = str(seat.get("areaId", seat.get("area_id", "")))
+            seat_no, area_id = normalize_library_seat(seat, fallback_area_id)
             if not seat_no or not area_id:
                 continue
 

--- a/campus_core/seat_reservation.py
+++ b/campus_core/seat_reservation.py
@@ -15,7 +15,7 @@ import requests
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
 
-from .time_utils import _now_dt, TimeUtilsMixin
+from .time_utils import _now_dt
 
 
 class SeatReservationMixin:
@@ -334,9 +334,17 @@ class SeatReservationMixin:
 
     @classmethod
     def _seat_summary(cls, seat: dict[str, Any]) -> dict[str, Any]:
+        seat_no = str(
+            seat.get("seatNo")
+            or seat.get("seat_no")
+            or seat.get("no")
+            or seat.get("name")
+            or ""
+        )
         return {
             "id": str(seat.get("id") or ""),
-            "no": str(seat.get("no") or seat.get("name") or ""),
+            "seat_no": seat_no,
+            "no": seat_no,
             "name": str(seat.get("name") or ""),
             "status": cls._seat_status(seat),
         }
@@ -751,21 +759,21 @@ class SeatReservationMixin:
             return None
 
         now = _now_dt()
-        hhmm = self._to_hhmm(text)
-        if re.fullmatch(r"\d{2}:\d{2}", hhmm):
-            hour, minute = [int(part) for part in hhmm.split(":")]
-            return now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        time_match = re.fullmatch(r"(\d{1,2})[:：](\d{1,2})", text)
+        if time_match:
+            hour, minute = (int(part) for part in time_match.groups())
+            try:
+                return now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+            except ValueError:
+                return None
 
         normalized = text.replace("Z", "+00:00")
         try:
             parsed = dt.datetime.fromisoformat(normalized)
         except ValueError:
             return None
-        if parsed.tzinfo is None:
-            try:
-                parsed = parsed.replace(tzinfo=ZoneInfo("Asia/Shanghai"))
-            except Exception:
-                pass
+        if parsed.tzinfo is None and now.tzinfo is not None:
+            parsed = parsed.replace(tzinfo=now.tzinfo)
         return parsed
 
     @staticmethod

--- a/henu_mcp/tools/server_impl.py
+++ b/henu_mcp/tools/server_impl.py
@@ -128,6 +128,8 @@ try:
         get_stats as _get_registry_stats,
         upsert_resource,
         get_resource,
+        normalize_library_location,
+        normalize_library_seat,
         sync_classrooms_from_metadata,
         sync_library_resources,
         sync_seminar_resources,
@@ -2108,7 +2110,16 @@ def _library_seats_impl(
     if hasattr(bot, "get_cas_cookies"):
         _save_cas_cookies(bot.get_cas_cookies())
     # 增量 sync 到 resource_registry
-    _enrich_library_seats(result.get("seats", []), target_area_id)
+    result_area = result.get("area")
+    resolved_area_id = ""
+    if isinstance(result_area, dict):
+        resolved_area_id = str(
+            result_area.get("id")
+            or result_area.get("area_id")
+            or result_area.get("areaId")
+            or ""
+        ).strip()
+    _enrich_library_seats(result.get("seats", []), target_area_id or resolved_area_id)
     return result
 
 
@@ -3184,8 +3195,7 @@ def _enrich_library_locations(locations: list[dict[str, Any]]) -> None:
         now = datetime.now().isoformat()
 
         for loc in locations:
-            area_id = str(loc.get("areaId", loc.get("area_id", loc.get("id", ""))))
-            area_name = str(loc.get("areaName", loc.get("area_name", loc.get("name", ""))))
+            area_id, area_name = normalize_library_location(loc)
             if not area_id or not area_name:
                 continue
 
@@ -3225,8 +3235,7 @@ def _enrich_library_seats(seats: list[dict[str, Any]], fallback_area_id: str = "
         now = datetime.now().isoformat()
 
         for seat in seats:
-            seat_no = str(seat.get("seatNo", seat.get("seat_no", seat.get("name", ""))))
-            area_id = str(seat.get("areaId", seat.get("area_id", fallback_area_id)))
+            seat_no, area_id = normalize_library_seat(seat, fallback_area_id)
             if not seat_no or not area_id:
                 continue
 

--- a/tests/test_library_resource_contract.py
+++ b/tests/test_library_resource_contract.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from campus_core.resource_registry import sync as registry_sync
+from campus_core.resource_registry.sync import (
+    normalize_library_location,
+    normalize_library_seat,
+)
+from henu_mcp.tools import server_impl
+
+
+def test_library_dto_normalization_accepts_public_query_shapes() -> None:
+    assert normalize_library_location(
+        {"location": "第一自习室", "area_id": "43"}
+    ) == ("43", "第一自习室")
+    assert normalize_library_seat({"no": "A-101"}, fallback_area_id="43") == (
+        "A-101",
+        "43",
+    )
+
+
+def test_registry_sync_reuses_normalization_for_single_area_seat_results() -> None:
+    records = []
+    with patch.object(registry_sync, "upsert_resource", side_effect=records.append):
+        result = registry_sync.sync_library_resources(
+            [{"location": "第一自习室", "area_id": "43"}],
+            [{"no": "A-101", "status": "1"}],
+        )
+
+    assert result == {"success": True, "synced_count": 2}
+    assert [record.resource_type for record in records] == [
+        "library_area",
+        "library_seat",
+    ]
+    assert records[1].location["areaId"] == "43"
+    assert records[1].location["seatNo"] == "A-101"
+
+
+class _LibraryBot:
+    def list_available_seats(self, **kwargs):
+        return {
+            "success": True,
+            "area": {"id": "43", "name": "第一自习室"},
+            "seats": [{"no": "A-101", "status": "1"}],
+        }
+
+    def get_cookies(self):
+        return {}
+
+    def get_cas_cookies(self):
+        return {}
+
+
+def test_library_seat_wrapper_uses_resolved_area_for_enrichment() -> None:
+    bot = _LibraryBot()
+    with (
+        patch.object(server_impl, "HenuCampusBot", object()),
+        patch.object(
+            server_impl,
+            "_effective_profile",
+            return_value={"student_id": "20230001", "password": "secret"},
+        ),
+        patch.object(server_impl, "_build_library_bot", return_value=bot),
+        patch.object(server_impl, "_save_library_cookies"),
+        patch.object(server_impl, "_save_cas_cookies"),
+        patch.object(server_impl, "_enrich_library_seats") as enrich,
+    ):
+        result = server_impl._library_seats_impl(location="第一自习室")
+
+    enrich.assert_called_once_with(result["seats"], "43")

--- a/tests/test_result_contract.py
+++ b/tests/test_result_contract.py
@@ -60,3 +60,5 @@ def test_live_locations_and_seats_expose_machine_readable_counts() -> None:
     assert seats["available_count"] == 1
     assert seats["returned_count"] == 1
     assert seats["status_counts"] == {"1": 1, "0": 1}
+    assert seats["seats"][0]["seat_no"] == "A-101"
+    assert seats["seats"][0]["no"] == "A-101"

--- a/tests/test_retry_until.py
+++ b/tests/test_retry_until.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import patch
+
+from campus_core import seat_reservation
+from campus_core.seat_reservation import SeatReservationMixin
+
+
+def test_retry_until_parses_clock_time_on_current_day() -> None:
+    now = dt.datetime(2026, 7, 13, 7, 30, tzinfo=dt.timezone(dt.timedelta(hours=8)))
+
+    with patch.object(seat_reservation, "_now_dt", return_value=now):
+        parsed = SeatReservationMixin._parse_retry_until("08:15")
+
+    assert parsed == now.replace(hour=8, minute=15, second=0, microsecond=0)
+
+
+def test_retry_until_preserves_iso_date_and_adds_local_timezone_when_missing() -> None:
+    timezone = dt.timezone(dt.timedelta(hours=8))
+    now = dt.datetime(2026, 7, 13, 7, 30, tzinfo=timezone)
+
+    with patch.object(seat_reservation, "_now_dt", return_value=now):
+        parsed = SeatReservationMixin._parse_retry_until("2026-07-14T08:15:00")
+
+    assert parsed == dt.datetime(2026, 7, 14, 8, 15, tzinfo=timezone)
+
+
+def test_retry_until_rejects_invalid_clock_time() -> None:
+    assert SeatReservationMixin._parse_retry_until("25:99") is None


### PR DESCRIPTION
## What changed

- Fix `library_reserve --retry_until` parsing for clock times and ISO datetimes.
- Normalize live library location/seat DTOs before resource-registry enrichment.
- Use the resolved area ID when a seat query starts from a location name.
- Expose the documented `seat_no` field while retaining `no` as a compatibility alias.
- Add regression tests for the parser and public library/resource contracts.

## Why

The retry parser referenced undefined names and discarded the date portion of ISO inputs. Library enrichment also expected field names that differ from the live query result, so valid areas and seats could be skipped.

## Impact

MCP clients get stable seat identifiers, retry deadlines parse correctly, and resource-registry records are populated from the same normalized DTO contract used by the query path.

## Validation

- `130 passed`
- `python3 diagnose_mcp.py` passed
- Ruff undefined-name check passed
- `git diff --check` passed