### PR TITLE
Harden Langbot storage transactions and cache contracts

### DIFF
--- a/campus_core/resource_registry/__init__.py
+++ b/campus_core/resource_registry/__init__.py
@@ -28,6 +28,8 @@ from .registry import (
 from .resolver import resolve_resource
 from .seed import preload_seed_if_needed
 from .sync import (
+    normalize_library_location,
+    normalize_library_seat,
     sync_classrooms_from_metadata,
     sync_library_resources,
     sync_seminar_resources,
@@ -56,6 +58,8 @@ __all__ = [
     # Resolver
     "resolve_resource",
     # Sync
+    "normalize_library_location",
+    "normalize_library_seat",
     "sync_classrooms_from_metadata",
     "sync_library_resources",
     "sync_seminar_resources",

--- a/campus_core/resource_registry/sync.py
+++ b/campus_core/resource_registry/sync.py
@@ -26,6 +26,40 @@ def _now_iso() -> str:
     return datetime.now().isoformat()
 
 
+def _first_text(data: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = data.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return ""
+
+
+def normalize_library_location(location: dict[str, Any]) -> tuple[str, str]:
+    """Return the canonical area ID and name from a library location DTO."""
+    if not isinstance(location, dict):
+        return "", ""
+    return (
+        _first_text(location, "areaId", "area_id", "id"),
+        _first_text(location, "areaName", "area_name", "name", "location"),
+    )
+
+
+def normalize_library_seat(
+    seat: dict[str, Any],
+    fallback_area_id: str = "",
+) -> tuple[str, str]:
+    """Return the canonical seat number and area ID from a seat DTO."""
+    if not isinstance(seat, dict):
+        return "", str(fallback_area_id or "").strip()
+    return (
+        _first_text(seat, "seatNo", "seat_no", "no", "name"),
+        _first_text(seat, "areaId", "area_id") or str(fallback_area_id or "").strip(),
+    )
+
+
 # ── 教室同步 ──────────────────────────────────────────────
 
 
@@ -172,10 +206,12 @@ def sync_library_resources(
     synced = 0
 
     library_id = "henu_library"  # 河南大学图书馆统一 ID
+    fallback_area_id = ""
+    if len(locations) == 1:
+        fallback_area_id, _ = normalize_library_location(locations[0])
 
     for loc in locations:
-        area_id = str(loc.get("areaId", loc.get("area_id", loc.get("id", ""))))
-        area_name = str(loc.get("areaName", loc.get("area_name", loc.get("name", ""))))
+        area_id, area_name = normalize_library_location(loc)
         if not area_id or not area_name:
             continue
 
@@ -196,8 +232,7 @@ def sync_library_resources(
 
     if seats:
         for seat in seats:
-            seat_no = str(seat.get("seatNo", seat.get("seat_no", seat.get("name", ""))))
-            area_id = str(seat.get("areaId", seat.get("area_id", "")))
+            seat_no, area_id = normalize_library_seat(seat, fallback_area_id)
             if not seat_no or not area_id:
                 continue
 

--- a/campus_core/seat_reservation.py
+++ b/campus_core/seat_reservation.py
@@ -15,7 +15,7 @@ import requests
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
 
-from .time_utils import _now_dt, TimeUtilsMixin
+from .time_utils import _now_dt
 
 
 class SeatReservationMixin:
@@ -334,9 +334,17 @@ class SeatReservationMixin:
 
     @classmethod
     def _seat_summary(cls, seat: dict[str, Any]) -> dict[str, Any]:
+        seat_no = str(
+            seat.get("seatNo")
+            or seat.get("seat_no")
+            or seat.get("no")
+            or seat.get("name")
+            or ""
+        )
         return {
             "id": str(seat.get("id") or ""),
-            "no": str(seat.get("no") or seat.get("name") or ""),
+            "seat_no": seat_no,
+            "no": seat_no,
             "name": str(seat.get("name") or ""),
             "status": cls._seat_status(seat),
         }
@@ -751,21 +759,21 @@ class SeatReservationMixin:
             return None
 
         now = _now_dt()
-        hhmm = self._to_hhmm(text)
-        if re.fullmatch(r"\d{2}:\d{2}", hhmm):
-            hour, minute = [int(part) for part in hhmm.split(":")]
-            return now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        time_match = re.fullmatch(r"(\d{1,2})[:：](\d{1,2})", text)
+        if time_match:
+            hour, minute = (int(part) for part in time_match.groups())
+            try:
+                return now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+            except ValueError:
+                return None
 
         normalized = text.replace("Z", "+00:00")
         try:
             parsed = dt.datetime.fromisoformat(normalized)
         except ValueError:
             return None
-        if parsed.tzinfo is None:
-            try:
-                parsed = parsed.replace(tzinfo=ZoneInfo("Asia/Shanghai"))
-            except Exception:
-                pass
+        if parsed.tzinfo is None and now.tzinfo is not None:
+            parsed = parsed.replace(tzinfo=now.tzinfo)
         return parsed
 
     @staticmethod

--- a/components/cli_tools/base.py
+++ b/components/cli_tools/base.py
@@ -11,7 +11,11 @@ from langbot_plugin.api.definition.components.tool.tool import Tool
 from langbot_plugin.api.entities.builtin.provider import session as provider_session
 from langbot_plugin.api.proxies.query_based_api import QueryBasedAPIProxy
 
-from henu_plugin.storage_adapter import PluginStorageAdapter
+from henu_plugin.storage_adapter import (
+    PluginStorageAdapter,
+    StorageLoadError,
+    storage_transaction,
+)
 from henu_plugin.service import get_current_user_paths, set_current_user_paths, SessionIdentity
 
 
@@ -54,46 +58,53 @@ class BaseHenuTool(Tool):
         storage_key = _resolve_storage_key(session, identity_hint)
         storage_adapter = PluginStorageAdapter(self.plugin, storage_key)
 
-        # Load user data from Storage to temp files
-        user_paths = await storage_adapter.load_all()
-
-        # Set thread-local paths for service to use
-        set_current_user_paths(user_paths)
-
         runtime_context = None
-        if self.should_preload_runtime_context(params):
-            await self._prime_runtime_context_query_var(query_id)
-            runtime_context = await self._ensure_runtime_context(
-                query_id,
-                session,
-                identity_hint,
-                service,
-            )
-
         result: dict[str, Any] | None = None
         storage_error: Exception | None = None
-        try:
-            result = await asyncio.to_thread(
-                service.run_tool,
-                self.tool_name,
-                params,
-                session,
-                query_id,
-                identity_hint,
-            )
-        finally:
-            # Save user data back to Storage after operation
+
+        # The shared temp directory and module-level runtime paths make the
+        # complete materialize -> execute -> persist lifecycle one transaction.
+        async with storage_transaction():
             try:
-                await storage_adapter.save_all()
-            except Exception as exc:
-                storage_error = exc
-            # Clear thread-local paths
-            set_current_user_paths(None)
+                user_paths = await storage_adapter.load_all()
+            except StorageLoadError:
+                return {
+                    "success": False,
+                    "error_code": "storage_load_failed",
+                    "msg": "LangBot Storage 读取失败，请稍后重试",
+                }
+
+            set_current_user_paths(user_paths)
+            try:
+                if self.should_preload_runtime_context(params):
+                    await self._prime_runtime_context_query_var(query_id)
+                    runtime_context = await self._ensure_runtime_context(
+                        query_id,
+                        session,
+                        identity_hint,
+                        service,
+                    )
+
+                result = await asyncio.to_thread(
+                    service.run_tool,
+                    self.tool_name,
+                    params,
+                    session,
+                    query_id,
+                    identity_hint,
+                )
+            finally:
+                try:
+                    await storage_adapter.save_all()
+                except Exception as exc:
+                    storage_error = exc
+                set_current_user_paths(None)
 
         if storage_error is not None:
             failure: dict[str, Any] = {
                 "success": False,
-                "msg": f"LangBot Storage 保存失败: {storage_error}",
+                "error_code": "storage_save_failed",
+                "msg": "LangBot Storage 保存失败，请稍后重试",
             }
             if isinstance(result, dict):
                 failure["tool_result"] = result

--- a/components/event_listener/identity_capture.py
+++ b/components/event_listener/identity_capture.py
@@ -11,7 +11,11 @@ from langbot_plugin.api.entities.builtin.provider import message as provider_mes
 from langbot_plugin.api.entities.builtin.provider import session as provider_session
 from langbot_plugin.api.entities import context, events
 
-from henu_plugin.storage_adapter import PluginStorageAdapter
+from henu_plugin.storage_adapter import (
+    PluginStorageAdapter,
+    StorageLoadError,
+    storage_transaction,
+)
 from henu_plugin.service import set_current_user_paths
 
 
@@ -464,15 +468,21 @@ class IdentityCaptureListener(EventListener):
     ) -> Any:
         storage_key = _resolve_storage_key(session, identity_hint)
         storage_adapter = PluginStorageAdapter(self.plugin, storage_key)
-        user_paths = await storage_adapter.load_all()
-        set_current_user_paths(user_paths)
-        try:
-            return await asyncio.to_thread(func, *args)
-        finally:
+
+        async with storage_transaction():
             try:
-                await storage_adapter.save_all()
+                user_paths = await storage_adapter.load_all()
+            except StorageLoadError:
+                return None
+
+            set_current_user_paths(user_paths)
+            try:
+                return await asyncio.to_thread(func, *args)
             finally:
-                set_current_user_paths(None)
+                try:
+                    await storage_adapter.save_all()
+                finally:
+                    set_current_user_paths(None)
 
     async def _safe_get_query_var(self, ctx: context.EventContext, key: str) -> object:
         try:

--- a/henu_mcp/tools/server_impl.py
+++ b/henu_mcp/tools/server_impl.py
@@ -128,6 +128,8 @@ try:
         get_stats as _get_registry_stats,
         upsert_resource,
         get_resource,
+        normalize_library_location,
+        normalize_library_seat,
         sync_classrooms_from_metadata,
         sync_library_resources,
         sync_seminar_resources,
@@ -2108,7 +2110,16 @@ def _library_seats_impl(
     if hasattr(bot, "get_cas_cookies"):
         _save_cas_cookies(bot.get_cas_cookies())
     # 增量 sync 到 resource_registry
-    _enrich_library_seats(result.get("seats", []), target_area_id)
+    result_area = result.get("area")
+    resolved_area_id = ""
+    if isinstance(result_area, dict):
+        resolved_area_id = str(
+            result_area.get("id")
+            or result_area.get("area_id")
+            or result_area.get("areaId")
+            or ""
+        ).strip()
+    _enrich_library_seats(result.get("seats", []), target_area_id or resolved_area_id)
     return result
 
 
@@ -3184,8 +3195,7 @@ def _enrich_library_locations(locations: list[dict[str, Any]]) -> None:
         now = datetime.now().isoformat()
 
         for loc in locations:
-            area_id = str(loc.get("areaId", loc.get("area_id", loc.get("id", ""))))
-            area_name = str(loc.get("areaName", loc.get("area_name", loc.get("name", ""))))
+            area_id, area_name = normalize_library_location(loc)
             if not area_id or not area_name:
                 continue
 
@@ -3225,8 +3235,7 @@ def _enrich_library_seats(seats: list[dict[str, Any]], fallback_area_id: str = "
         now = datetime.now().isoformat()
 
         for seat in seats:
-            seat_no = str(seat.get("seatNo", seat.get("seat_no", seat.get("name", ""))))
-            area_id = str(seat.get("areaId", seat.get("area_id", fallback_area_id)))
+            seat_no, area_id = normalize_library_seat(seat, fallback_area_id)
             if not seat_no or not area_id:
                 continue
 

--- a/henu_plugin/cache.py
+++ b/henu_plugin/cache.py
@@ -4,6 +4,7 @@ Provides thread-safe caching with configurable TTL to reduce file I/O and API ca
 """
 from __future__ import annotations
 
+import copy
 import time
 import threading
 from dataclasses import dataclass, field
@@ -55,7 +56,7 @@ class TTLCache(Generic[T]):
             if entry.is_expired():
                 del self._cache[key]
                 return None
-            return entry.value
+            return copy.deepcopy(entry.value)
 
     def set(
         self,
@@ -67,7 +68,7 @@ class TTLCache(Generic[T]):
         ttl = ttl_seconds if ttl_seconds is not None else self._default_ttl
         with self._lock:
             self._cache[key] = CacheEntry(
-                value=value,
+                value=copy.deepcopy(value),
                 created_at=time.time(),
                 ttl_seconds=ttl,
             )

--- a/henu_plugin/service.py
+++ b/henu_plugin/service.py
@@ -586,6 +586,7 @@ class HenuPluginService:
         view = _text(params.get("view")) or "current"
         timezone = _text(params.get("timezone")) or "Asia/Shanghai"
         target_date = _text(params.get("target_date")) or ""
+        auto_calibrate = _bool(params.get("auto_calibrate"), True)
 
         # Try to restore schedule from Storage if not in output_dir
         paths = get_current_user_paths()
@@ -604,9 +605,14 @@ class HenuPluginService:
                 except Exception:
                     pass
 
-        # Try cache for read-only views
+        cache_key: str | None = None
+        # Try cache for read-only views. Current/now results are time-sensitive,
+        # while week/full only change when the stored schedule is invalidated.
         if identity and view in {"current", "now", "week", "full"}:
-            cache_key = f"user:{identity.storage_key}:schedule:{view}:{target_date}"
+            cache_key = (
+                f"user:{identity.storage_key}:schedule:{view}:{timezone}:"
+                f"{target_date}:{int(auto_calibrate)}"
+            )
             cached = SCHEDULE_CACHE.get(cache_key)
             if cached is not None:
                 return cached
@@ -615,12 +621,12 @@ class HenuPluginService:
             view=view,
             timezone=timezone,
             target_date=target_date,
-            auto_calibrate=_bool(params.get("auto_calibrate"), True),
+            auto_calibrate=auto_calibrate,
         )
 
-        # Cache successful read-only queries (permanent TTL)
-        if result.get("success") and identity and view in {"current", "now", "week", "full"}:
-            SCHEDULE_CACHE.set(cache_key, result, ttl_seconds=315360000.0)  # 10 years
+        if result.get("success") and cache_key is not None:
+            ttl_seconds = 30.0 if view in {"current", "now"} else 315360000.0
+            SCHEDULE_CACHE.set(cache_key, result, ttl_seconds=ttl_seconds)
 
         return result
 
@@ -744,11 +750,52 @@ class HenuPluginService:
         identity = getattr(_CURRENT_IDENTITY, "value", None)
         view = _text(params.get("view")) or "rooms"
         target_date = _text(params.get("target_date")) or ""
+        members = _int(params.get("members"), 0)
+        name = _text(params.get("name"))
+        room = _text(params.get("room"))
+        start_time = _text(params.get("start_time"))
+        end_time = _text(params.get("end_time"))
+        library_ids = _text(params.get("library_ids"))
+        library_names = _text(params.get("library_names"))
+        floor_ids = _text(params.get("floor_ids"))
+        floor_names = _text(params.get("floor_names"))
+        category_ids = _text(params.get("category_ids"))
+        category_names = _text(params.get("category_names"))
+        boutique_ids = _text(params.get("boutique_ids"))
+        boutique_names = _text(params.get("boutique_names"))
         page = _int(params.get("page"), 1)
+        area_id = _text(params.get("area_id"))
+        record_type = _text(params.get("record_type")) or "1"
+        limit = _int(params.get("limit"), 20)
+        mode = _text(params.get("mode")) or "books"
+        status = _text(params.get("status"))
 
-        # Try cache for read operations
+        cache_key: str | None = None
         if identity and view in {"rooms", "filters", "detail"}:
-            cache_key = f"user:{identity.storage_key}:seminar:{view}:{target_date}:{page}"
+            signature = (
+                view,
+                target_date,
+                members,
+                name,
+                room,
+                start_time,
+                end_time,
+                library_ids,
+                library_names,
+                floor_ids,
+                floor_names,
+                category_ids,
+                category_names,
+                boutique_ids,
+                boutique_names,
+                page,
+                area_id,
+                record_type,
+                limit,
+                mode,
+                status,
+            )
+            cache_key = f"user:{identity.storage_key}:seminar:{signature!r}"
             cached = SEMINAR_QUERY_CACHE.get(cache_key)
             if cached is not None:
                 return cached
@@ -756,29 +803,28 @@ class HenuPluginService:
         result = mcp_server.seminar_query(
             view=view,
             target_date=target_date,
-            members=_int(params.get("members"), 0),
-            name=_text(params.get("name")),
-            room=_text(params.get("room")),
-            start_time=_text(params.get("start_time")),
-            end_time=_text(params.get("end_time")),
-            library_ids=_text(params.get("library_ids")),
-            library_names=_text(params.get("library_names")),
-            floor_ids=_text(params.get("floor_ids")),
-            floor_names=_text(params.get("floor_names")),
-            category_ids=_text(params.get("category_ids")),
-            category_names=_text(params.get("category_names")),
-            boutique_ids=_text(params.get("boutique_ids")),
-            boutique_names=_text(params.get("boutique_names")),
+            members=members,
+            name=name,
+            room=room,
+            start_time=start_time,
+            end_time=end_time,
+            library_ids=library_ids,
+            library_names=library_names,
+            floor_ids=floor_ids,
+            floor_names=floor_names,
+            category_ids=category_ids,
+            category_names=category_names,
+            boutique_ids=boutique_ids,
+            boutique_names=boutique_names,
             page=page,
-            area_id=_text(params.get("area_id")),
-            record_type=_text(params.get("record_type")) or "1",
-            limit=_int(params.get("limit"), 20),
-            mode=_text(params.get("mode")) or "books",
-            status=_text(params.get("status")),
+            area_id=area_id,
+            record_type=record_type,
+            limit=limit,
+            mode=mode,
+            status=status,
         )
 
-        # Cache successful queries
-        if result.get("success") and identity and view in {"rooms", "filters", "detail"}:
+        if result.get("success") and cache_key is not None:
             SEMINAR_QUERY_CACHE.set(cache_key, result)
 
         return result

--- a/henu_plugin/storage_adapter.py
+++ b/henu_plugin/storage_adapter.py
@@ -12,9 +12,11 @@ Usage:
 
 from __future__ import annotations
 
-import json
+import asyncio
 import logging
 import tempfile
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -23,6 +25,34 @@ if TYPE_CHECKING:
     from langbot_plugin.api.definition.plugin import BasePlugin
 
 logger = logging.getLogger(__name__)
+
+
+class StorageLoadError(RuntimeError):
+    """Raised when persisted plugin data cannot be materialized safely."""
+
+
+class StorageSaveError(RuntimeError):
+    """Raised when materialized plugin data cannot be persisted safely."""
+
+
+_STORAGE_TRANSACTION_LOCK_ATTR = "_henu_storage_transaction_lock"
+
+
+def _get_storage_transaction_lock() -> asyncio.Lock:
+    """Return the transaction lock associated with the active LangBot loop."""
+    loop = asyncio.get_running_loop()
+    lock = getattr(loop, _STORAGE_TRANSACTION_LOCK_ATTR, None)
+    if lock is None:
+        lock = asyncio.Lock()
+        setattr(loop, _STORAGE_TRANSACTION_LOCK_ATTR, lock)
+    return lock
+
+
+@asynccontextmanager
+async def storage_transaction() -> AsyncIterator[None]:
+    """Serialize materialize -> execute -> persist across shared temp state."""
+    async with _get_storage_transaction_lock():
+        yield
 
 # Storage key prefixes for different data types
 PREFIX_PROFILE = "user:{}:profile"
@@ -83,7 +113,7 @@ class PluginStorageAdapter:
         self._plugin = plugin
         self._storage_key = storage_key
         self._paths: UserStoragePaths | None = None
-        self._dirty: set[str] = set()  # Track which files were modified
+        self._loaded_content: dict[str, bytes] = {}
 
     def _key(self, prefix_template: str) -> str:
         """Create a storage key with user prefix."""
@@ -92,8 +122,15 @@ class PluginStorageAdapter:
     async def load_all(self) -> UserStoragePaths:
         """Load all user data from Storage to local temp files.
 
+        Concurrent callers must hold ``storage_transaction()`` until the
+        matching ``save_all()`` completes because user and shared temp paths
+        are reused between operations.
+
         Returns paths to local temp files for file operations.
         """
+        self._paths = None
+        self._loaded_content.clear()
+
         # Ensure shared temp directory exists
         if PluginStorageAdapter._shared_temp_dir is None:
             PluginStorageAdapter._shared_temp_dir = Path(
@@ -109,7 +146,7 @@ class PluginStorageAdapter:
         shared_data_dir = PluginStorageAdapter._shared_temp_dir / "shared"
         shared_data_dir.mkdir(parents=True, exist_ok=True)
 
-        self._paths = UserStoragePaths(
+        paths = UserStoragePaths(
             user_root=user_root,
             profile_file=user_root / "profile.json",
             xk_cookie_file=user_root / "xk_cookies.json",
@@ -124,104 +161,117 @@ class PluginStorageAdapter:
             shared_data_dir=shared_data_dir,
         )
 
-        # Load each data type from Storage (async)
-        await self._load_json(self._key(PREFIX_PROFILE), self._paths.profile_file)
-        await self._load_json(self._key(PREFIX_XK_COOKIE), self._paths.xk_cookie_file)
-        await self._load_json(
-            self._key(PREFIX_LIBRARY_COOKIE), self._paths.library_cookie_file
-        )
-        await self._load_json(
-            self._key(PREFIX_SEMINAR_TASK), self._paths.seminar_signin_task_file
-        )
-        await self._load_json(self._key(PREFIX_SCHEDULE), self._paths.schedule_file)
-        await self._load_json(self._key(PREFIX_YUNFZ_TOKEN), self._paths.yunfz_token_file)
-        await self._load_json(self._key(PREFIX_CAS_COOKIE), self._paths.cas_cookie_file)
-        await self._load_json(
-            self._key(PREFIX_COURSE_MONITOR_CONFIG), self._paths.course_monitor_config_file
-        )
-        await self._load_json(
-            self._key(PREFIX_COURSE_MONITOR_STATE), self._paths.course_monitor_state_file
-        )
-        await self._load_json(
-            PREFIX_SHARED_PERIOD_TIME,
-            self._paths.shared_data_dir / SHARED_PERIOD_TIME_FILE,
-        )
-        await self._load_json(
-            PREFIX_SHARED_CALIBRATION,
-            self._paths.shared_data_dir / SHARED_CALIBRATION_FILE,
-        )
-        await self._load_json(
-            PREFIX_SHARED_XIQUEER,
-            self._paths.shared_data_dir / SHARED_XIQUEER_FILE,
-        )
+        loaded_content: dict[str, bytes] = {}
+        try:
+            existing_storage_keys = await self._existing_storage_keys()
+            for storage_key, file_path in self._storage_bindings(paths):
+                if storage_key in existing_storage_keys:
+                    loaded_content[storage_key] = await self._load_json(
+                        storage_key,
+                        file_path,
+                    )
+                else:
+                    loaded_content[storage_key] = self._materialize_json(
+                        storage_key,
+                        file_path,
+                        b"",
+                    )
+        except Exception:
+            # A partial materialization must never become eligible for save_all().
+            self._paths = None
+            self._loaded_content.clear()
+            raise
 
-        self._dirty.clear()
-        return self._paths
+        self._paths = paths
+        self._loaded_content = loaded_content
+        return paths
 
     async def save_all(self) -> None:
         """Save all local temp files back to Storage."""
         if self._paths is None:
             return
 
-        # Save user data
-        await self._save_json(self._paths.profile_file, self._key(PREFIX_PROFILE))
-        await self._save_json(self._paths.xk_cookie_file, self._key(PREFIX_XK_COOKIE))
-        await self._save_json(
-            self._paths.library_cookie_file, self._key(PREFIX_LIBRARY_COOKIE)
-        )
-        await self._save_json(
-            self._paths.seminar_signin_task_file, self._key(PREFIX_SEMINAR_TASK)
-        )
-        await self._save_json(self._paths.schedule_file, self._key(PREFIX_SCHEDULE))
-        await self._save_json(self._paths.yunfz_token_file, self._key(PREFIX_YUNFZ_TOKEN))
-        await self._save_json(self._paths.cas_cookie_file, self._key(PREFIX_CAS_COOKIE))
-        await self._save_json(
-            self._paths.course_monitor_config_file, self._key(PREFIX_COURSE_MONITOR_CONFIG)
-        )
-        await self._save_json(
-            self._paths.course_monitor_state_file, self._key(PREFIX_COURSE_MONITOR_STATE)
-        )
-        await self._save_json(
-            self._paths.shared_data_dir / SHARED_PERIOD_TIME_FILE,
-            PREFIX_SHARED_PERIOD_TIME,
-        )
-        await self._save_json(
-            self._paths.shared_data_dir / SHARED_CALIBRATION_FILE,
-            PREFIX_SHARED_CALIBRATION,
-        )
-        await self._save_json(
-            self._paths.shared_data_dir / SHARED_XIQUEER_FILE,
-            PREFIX_SHARED_XIQUEER,
-        )
+        for storage_key, file_path in self._storage_bindings(self._paths):
+            baseline = self._loaded_content.get(storage_key)
+            if baseline is None or not file_path.exists():
+                continue
+            try:
+                current = file_path.read_bytes()
+            except OSError as exc:
+                raise StorageSaveError(f"读取待保存文件失败: {file_path}") from exc
+            if current == baseline:
+                continue
+            await self._save_json(file_path, storage_key, data=current)
+            self._loaded_content[storage_key] = current
 
-        self._dirty.clear()
+    def _storage_bindings(self, paths: UserStoragePaths) -> list[tuple[str, Path]]:
+        """Map every persisted Storage key to its materialized file."""
+        return [
+            (self._key(PREFIX_PROFILE), paths.profile_file),
+            (self._key(PREFIX_XK_COOKIE), paths.xk_cookie_file),
+            (self._key(PREFIX_LIBRARY_COOKIE), paths.library_cookie_file),
+            (self._key(PREFIX_SEMINAR_TASK), paths.seminar_signin_task_file),
+            (self._key(PREFIX_SCHEDULE), paths.schedule_file),
+            (self._key(PREFIX_YUNFZ_TOKEN), paths.yunfz_token_file),
+            (self._key(PREFIX_CAS_COOKIE), paths.cas_cookie_file),
+            (self._key(PREFIX_COURSE_MONITOR_CONFIG), paths.course_monitor_config_file),
+            (self._key(PREFIX_COURSE_MONITOR_STATE), paths.course_monitor_state_file),
+            (PREFIX_SHARED_PERIOD_TIME, paths.shared_data_dir / SHARED_PERIOD_TIME_FILE),
+            (PREFIX_SHARED_CALIBRATION, paths.shared_data_dir / SHARED_CALIBRATION_FILE),
+            (PREFIX_SHARED_XIQUEER, paths.shared_data_dir / SHARED_XIQUEER_FILE),
+        ]
 
-    async def _load_json(self, storage_key: str, file_path: Path) -> None:
+    async def _existing_storage_keys(self) -> set[str]:
+        """List persisted keys so a missing key is not treated as a read failure."""
+        try:
+            keys = await self._plugin.get_plugin_storage_keys()
+            return {str(key) for key in keys}
+        except Exception as exc:
+            logger.warning("Failed to list LangBot Storage keys: %s", exc)
+            raise StorageLoadError("列出 LangBot Storage 键失败") from exc
+
+    def _materialize_json(
+        self,
+        storage_key: str,
+        file_path: Path,
+        data: bytes,
+    ) -> bytes:
+        """Write persisted bytes, or an empty JSON object for a missing key."""
+        materialized = data if data else b"{}"
+        try:
+            file_path.write_bytes(materialized)
+        except OSError as exc:
+            raise StorageLoadError(f"写入临时 Storage 文件失败: {storage_key}") from exc
+        logger.debug("Loaded %s bytes from Storage: %s", len(data), storage_key)
+        return materialized
+
+    async def _load_json(self, storage_key: str, file_path: Path) -> bytes:
         """Load JSON data from Storage and write to local file."""
         try:
             data = await self._plugin.get_plugin_storage(storage_key)
-            if data:
-                file_path.write_bytes(data)
-                logger.debug(f"Loaded {len(data)} bytes from Storage: {storage_key}")
-            else:
-                # No data in storage, create empty JSON file
-                file_path.write_text("{}", encoding="utf-8")
         except Exception as e:
-            # Key doesn't exist or other error - create empty file
-            logger.debug(f"No data in Storage for {storage_key}: {e}")
-            file_path.write_text("{}", encoding="utf-8")
+            logger.warning("Failed to load Storage key %s: %s", storage_key, e)
+            raise StorageLoadError(f"读取 LangBot Storage 失败: {storage_key}") from e
 
-    async def _save_json(self, file_path: Path, storage_key: str) -> None:
+        return self._materialize_json(storage_key, file_path, data)
+
+    async def _save_json(
+        self,
+        file_path: Path,
+        storage_key: str,
+        *,
+        data: bytes | None = None,
+    ) -> None:
         """Save local file content to Storage."""
         if not file_path.exists():
             return
         try:
-            data = file_path.read_bytes()
-            await self._plugin.set_plugin_storage(storage_key, data)
-            logger.debug(f"Saved {len(data)} bytes to Storage: {storage_key}")
+            payload = file_path.read_bytes() if data is None else data
+            await self._plugin.set_plugin_storage(storage_key, payload)
+            logger.debug("Saved %s bytes to Storage: %s", len(payload), storage_key)
         except Exception as e:
-            logger.warning(f"Failed to save to Storage {storage_key}: {e}")
-            raise
+            logger.warning("Failed to save to Storage %s: %s", storage_key, e)
+            raise StorageSaveError(f"保存 LangBot Storage 失败: {storage_key}") from e
 
     # Shared data methods (cross-user)
     async def load_shared_period_time(self, file_path: Path) -> None:

--- a/tests/test_cache_contract.py
+++ b/tests/test_cache_contract.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+try:
+    import langbot_plugin  # noqa: F401
+except ModuleNotFoundError:
+    module_names = (
+        "langbot_plugin",
+        "langbot_plugin.api",
+        "langbot_plugin.api.entities",
+        "langbot_plugin.api.entities.builtin",
+        "langbot_plugin.api.entities.builtin.provider",
+        "langbot_plugin.api.entities.builtin.provider.session",
+    )
+    for module_name in module_names:
+        sys.modules[module_name] = types.ModuleType(module_name)
+    provider = sys.modules["langbot_plugin.api.entities.builtin.provider"]
+    provider.session = sys.modules["langbot_plugin.api.entities.builtin.provider.session"]
+
+from henu_plugin import service as service_module
+from henu_plugin.cache import (
+    SCHEDULE_CACHE,
+    TTLCache,
+    clear_all_caches,
+)
+from henu_plugin.service import HenuPluginService
+
+
+def test_ttl_cache_copies_values_at_set_and_get_boundaries() -> None:
+    cache: TTLCache[dict] = TTLCache()
+    source = {"rows": [{"id": 1}, {"id": 2}]}
+
+    cache.set("rows", source)
+    source["rows"].pop()
+    first_read = cache.get("rows")
+
+    assert first_read == {"rows": [{"id": 1}, {"id": 2}]}
+    first_read["rows"].clear()
+    assert cache.get("rows") == {"rows": [{"id": 1}, {"id": 2}]}
+
+
+def test_current_schedule_cache_separates_timezone_and_expires_quickly() -> None:
+    clear_all_caches()
+    service_module._CURRENT_IDENTITY.value = SimpleNamespace(storage_key="qq_10001")
+    service = HenuPluginService(Path("."))
+
+    def schedule_result(**kwargs):
+        return {"success": True, "timezone": kwargs["timezone"]}
+
+    try:
+        with patch.object(service_module.mcp_server, "schedule_query", side_effect=schedule_result) as query:
+            shanghai = service._schedule_query({"view": "current", "timezone": "Asia/Shanghai"})
+            utc = service._schedule_query({"view": "current", "timezone": "UTC"})
+
+            assert shanghai["timezone"] == "Asia/Shanghai"
+            assert utc["timezone"] == "UTC"
+            assert query.call_count == 2
+
+            utc["timezone"] = "mutated by delivery layer"
+            assert service._schedule_query({"view": "current", "timezone": "UTC"})["timezone"] == "UTC"
+            assert query.call_count == 2
+
+            utc_entry = next(
+                entry
+                for key, entry in SCHEDULE_CACHE._cache.items()
+                if ":schedule:current:UTC:" in key
+            )
+            assert utc_entry.ttl_seconds == 30.0
+            utc_entry.created_at -= 31.0
+            service._schedule_query({"view": "current", "timezone": "UTC"})
+            assert query.call_count == 3
+    finally:
+        service_module._CURRENT_IDENTITY.value = None
+        clear_all_caches()
+
+
+def test_seminar_cache_key_includes_effective_filters() -> None:
+    clear_all_caches()
+    service_module._CURRENT_IDENTITY.value = SimpleNamespace(storage_key="qq_10001")
+    service = HenuPluginService(Path("."))
+
+    def seminar_result(**kwargs):
+        return {"success": True, "members": kwargs["members"], "room": kwargs["room"]}
+
+    try:
+        with patch.object(service_module.mcp_server, "seminar_query", side_effect=seminar_result) as query:
+            small = service._seminar_query(
+                {"view": "rooms", "target_date": "2026-07-14", "members": 2, "room": "A"}
+            )
+            large = service._seminar_query(
+                {"view": "rooms", "target_date": "2026-07-14", "members": 6, "room": "B"}
+            )
+
+            assert small == {"success": True, "members": 2, "room": "A"}
+            assert large == {"success": True, "members": 6, "room": "B"}
+            assert query.call_count == 2
+
+            assert service._seminar_query(
+                {"view": "rooms", "target_date": "2026-07-14", "members": 2, "room": "A"}
+            ) == small
+            assert query.call_count == 2
+    finally:
+        service_module._CURRENT_IDENTITY.value = None
+        clear_all_caches()

--- a/tests/test_library_resource_contract.py
+++ b/tests/test_library_resource_contract.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from campus_core.resource_registry import sync as registry_sync
+from campus_core.resource_registry.sync import (
+    normalize_library_location,
+    normalize_library_seat,
+)
+from campus_core.seat_reservation import SeatReservationMixin
+from henu_mcp.tools import server_impl
+
+
+def test_library_dto_normalization_accepts_public_query_shapes() -> None:
+    assert normalize_library_location(
+        {"location": "第一自习室", "area_id": "43"}
+    ) == ("43", "第一自习室")
+    assert normalize_library_seat({"no": "A-101"}, fallback_area_id="43") == (
+        "A-101",
+        "43",
+    )
+
+
+def test_public_seat_summary_keeps_seat_no_and_legacy_no_alias() -> None:
+    summary = SeatReservationMixin._seat_summary(
+        {"id": "1", "no": "A-101", "name": "A-101", "status": "1"}
+    )
+
+    assert summary["seat_no"] == "A-101"
+    assert summary["no"] == "A-101"
+
+
+def test_registry_sync_reuses_normalization_for_single_area_seat_results() -> None:
+    records = []
+    with patch.object(registry_sync, "upsert_resource", side_effect=records.append):
+        result = registry_sync.sync_library_resources(
+            [{"location": "第一自习室", "area_id": "43"}],
+            [{"no": "A-101", "status": "1"}],
+        )
+
+    assert result == {"success": True, "synced_count": 2}
+    assert [record.resource_type for record in records] == [
+        "library_area",
+        "library_seat",
+    ]
+    assert records[1].location["areaId"] == "43"
+    assert records[1].location["seatNo"] == "A-101"
+
+
+class _LibraryBot:
+    def list_available_seats(self, **kwargs):
+        return {
+            "success": True,
+            "area": {"id": "43", "name": "第一自习室"},
+            "seats": [{"no": "A-101", "status": "1"}],
+        }
+
+    def get_cookies(self):
+        return {}
+
+    def get_cas_cookies(self):
+        return {}
+
+
+def test_library_seat_wrapper_uses_resolved_area_for_enrichment() -> None:
+    bot = _LibraryBot()
+    with (
+        patch.object(server_impl, "HenuCampusBot", object()),
+        patch.object(
+            server_impl,
+            "_effective_profile",
+            return_value={"student_id": "20230001", "password": "secret"},
+        ),
+        patch.object(server_impl, "_build_library_bot", return_value=bot),
+        patch.object(server_impl, "_save_library_cookies"),
+        patch.object(server_impl, "_save_cas_cookies"),
+        patch.object(server_impl, "_enrich_library_seats") as enrich,
+    ):
+        result = server_impl._library_seats_impl(location="第一自习室")
+
+    enrich.assert_called_once_with(result["seats"], "43")

--- a/tests/test_retry_until.py
+++ b/tests/test_retry_until.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import patch
+
+from campus_core import seat_reservation
+from campus_core.seat_reservation import SeatReservationMixin
+
+
+def test_retry_until_parses_clock_time_on_current_day() -> None:
+    now = dt.datetime(2026, 7, 13, 7, 30, tzinfo=dt.timezone(dt.timedelta(hours=8)))
+
+    with patch.object(seat_reservation, "_now_dt", return_value=now):
+        parsed = SeatReservationMixin._parse_retry_until("08:15")
+
+    assert parsed == now.replace(hour=8, minute=15, second=0, microsecond=0)
+
+
+def test_retry_until_preserves_iso_date_and_adds_local_timezone_when_missing() -> None:
+    timezone = dt.timezone(dt.timedelta(hours=8))
+    now = dt.datetime(2026, 7, 13, 7, 30, tzinfo=timezone)
+
+    with patch.object(seat_reservation, "_now_dt", return_value=now):
+        parsed = SeatReservationMixin._parse_retry_until("2026-07-14T08:15:00")
+
+    assert parsed == dt.datetime(2026, 7, 14, 8, 15, tzinfo=timezone)
+
+
+def test_retry_until_rejects_invalid_clock_time() -> None:
+    assert SeatReservationMixin._parse_retry_until("25:99") is None

--- a/tests/test_storage_adapter.py
+++ b/tests/test_storage_adapter.py
@@ -1,28 +1,50 @@
 from __future__ import annotations
 
+import asyncio
 import tempfile
 import unittest
 from pathlib import Path
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from henu_plugin.storage_adapter import PluginStorageAdapter
+from henu_plugin.storage_adapter import (
+    PluginStorageAdapter,
+    StorageLoadError,
+    storage_transaction,
+)
 
 
 class _FakePlugin:
     def __init__(self) -> None:
         self.storage: dict[str, bytes] = {}
+        self.get_calls: list[str] = []
+        self.set_calls: list[str] = []
 
     async def get_plugin_storage(self, storage_key: str) -> bytes:
-        return self.storage.get(storage_key, b"")
+        self.get_calls.append(storage_key)
+        return self.storage[storage_key]
+
+    async def get_plugin_storage_keys(self) -> list[str]:
+        return list(self.storage)
 
     async def set_plugin_storage(self, storage_key: str, data: bytes) -> None:
+        self.set_calls.append(storage_key)
         self.storage[storage_key] = data
 
 
 class _FailingSavePlugin(_FakePlugin):
     async def set_plugin_storage(self, storage_key: str, data: bytes) -> None:
         raise RuntimeError(f"storage unavailable: {storage_key}")
+
+
+class _FailingLoadPlugin(_FakePlugin):
+    async def get_plugin_storage(self, storage_key: str) -> bytes:
+        raise RuntimeError(f"temporary read failure: {storage_key}")
+
+
+class _FailingKeysPlugin(_FakePlugin):
+    async def get_plugin_storage_keys(self) -> list[str]:
+        raise RuntimeError("temporary key listing failure")
 
 
 class PluginStorageAdapterTests(unittest.IsolatedAsyncioTestCase):
@@ -35,11 +57,14 @@ class PluginStorageAdapterTests(unittest.IsolatedAsyncioTestCase):
         self._tmp.cleanup()
 
     async def test_load_all_populates_shared_data_dir(self) -> None:
-        paths = await PluginStorageAdapter(_FakePlugin(), "qq_10001").load_all()
+        plugin = _FakePlugin()
+        paths = await PluginStorageAdapter(plugin, "qq_10001").load_all()
 
         self.assertEqual(paths.shared_data_dir, Path(self._tmp.name) / "shared")
         self.assertTrue(paths.shared_data_dir.is_dir())
         self.assertTrue(paths.profile_file.exists())
+        self.assertEqual(paths.profile_file.read_bytes(), b"{}")
+        self.assertEqual(plugin.get_calls, [])
 
     async def test_load_all_materializes_user_private_cas_cookie_and_shared_configs(self) -> None:
         plugin = _FakePlugin()
@@ -90,6 +115,88 @@ class PluginStorageAdapterTests(unittest.IsolatedAsyncioTestCase):
 
         with self.assertRaises(RuntimeError):
             await adapter.save_all()
+
+    async def test_load_failure_never_materializes_a_saveable_empty_profile(self) -> None:
+        plugin = _FailingLoadPlugin()
+        plugin.storage["user:qq_10001:profile"] = b'{"student_id":"20230001"}'
+        adapter = PluginStorageAdapter(plugin, "qq_10001")
+
+        with self.assertRaises(StorageLoadError):
+            await adapter.load_all()
+        await adapter.save_all()
+
+        self.assertEqual(
+            plugin.storage["user:qq_10001:profile"],
+            b'{"student_id":"20230001"}',
+        )
+        self.assertEqual(plugin.set_calls, [])
+
+    async def test_key_listing_failure_never_enables_save_all(self) -> None:
+        plugin = _FailingKeysPlugin()
+        adapter = PluginStorageAdapter(plugin, "qq_10001")
+
+        with self.assertRaises(StorageLoadError):
+            await adapter.load_all()
+        await adapter.save_all()
+
+        self.assertEqual(plugin.set_calls, [])
+
+    async def test_save_all_only_persists_materialized_files_that_changed(self) -> None:
+        plugin = _FakePlugin()
+        plugin.storage["user:qq_10001:profile"] = b'{"student_id":"old"}'
+        adapter = PluginStorageAdapter(plugin, "qq_10001")
+        paths = await adapter.load_all()
+
+        await adapter.save_all()
+        self.assertEqual(plugin.set_calls, [])
+
+        paths.profile_file.write_text('{"student_id":"new"}', encoding="utf-8")
+        await adapter.save_all()
+
+        self.assertEqual(plugin.set_calls, ["user:qq_10001:profile"])
+        self.assertEqual(
+            plugin.storage["user:qq_10001:profile"],
+            b'{"student_id":"new"}',
+        )
+
+    async def test_storage_transaction_serializes_materialize_execute_persist(self) -> None:
+        plugin = _FakePlugin()
+        plugin.storage["user:qq_10001:profile"] = b'{"student_id":"old"}'
+        first_loaded = asyncio.Event()
+        release_first = asyncio.Event()
+        entered: list[str] = []
+        observed_by_second: list[str] = []
+
+        async def first_operation() -> None:
+            async with storage_transaction():
+                adapter = PluginStorageAdapter(plugin, "qq_10001")
+                paths = await adapter.load_all()
+                entered.append("first")
+                paths.profile_file.write_text('{"student_id":"new"}', encoding="utf-8")
+                first_loaded.set()
+                await release_first.wait()
+                await adapter.save_all()
+
+        async def second_operation() -> None:
+            await first_loaded.wait()
+            async with storage_transaction():
+                adapter = PluginStorageAdapter(plugin, "qq_10001")
+                paths = await adapter.load_all()
+                entered.append("second")
+                observed_by_second.append(paths.profile_file.read_text(encoding="utf-8"))
+                await adapter.save_all()
+
+        first_task = asyncio.create_task(first_operation())
+        second_task = asyncio.create_task(second_operation())
+        await first_loaded.wait()
+        await asyncio.sleep(0)
+        self.assertEqual(entered, ["first"])
+
+        release_first.set()
+        await asyncio.gather(first_task, second_task)
+
+        self.assertEqual(entered, ["first", "second"])
+        self.assertEqual(observed_by_second, ['{"student_id":"new"}'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Mirror the shared retry parsing and library DTO/result-contract fixes.
- Make Storage materialization fail closed on key-list or existing-key read failures.
- Treat genuinely missing Storage keys as first-use empty data without writing them back unless changed.
- Persist only files whose bytes changed after materialization.
- Serialize the full materialize → execute → persist lifecycle used by both Langbot entrypoints.
- Deep-copy cache values and include all effective schedule/seminar inputs in cache keys.
- Limit time-sensitive current/now schedule results to a 30-second TTL.
- Add regression coverage for Storage failures, first-use keys, transaction serialization, cache isolation, filter keys, and shared library behavior.

## Why

Transient Storage reads were indistinguishable from missing data, so a failed read could be materialized as `{}` and later overwrite valid persisted profiles. Concurrent invocations also reused module-level runtime paths and temporary files outside the existing execution lock, allowing one request to roll back another request's data. Cache keys omitted behavior-changing parameters and returned mutable objects by reference.

## Impact

Per-QQ data now fails safely instead of being silently replaced, concurrent requests cannot interleave the shared runtime transaction, and cached results remain isolated and correctly scoped.

## Validation

- `48 passed`
- `lbp build` succeeded with `langbot-plugin==0.1.1b1`
- Cross-review found no blocking issue
- Ruff undefined-name check passed
- `git diff --check` passed